### PR TITLE
fix hrtb for Handler and Responder

### DIFF
--- a/http/src/util/service/handler.rs
+++ b/http/src/util/service/handler.rs
@@ -116,13 +116,12 @@ pub trait Handler<'a, Req, T>: Clone {
 impl<'a, Req, T, Res, Err, F> Handler<'a, Req, T> for F
 where
     T: FromRequest<'static, Req, Error = Err>,
-    Req: 'a,
-    F: AsyncFn<T::Type<'a>, Output = Res> + Clone + 'a,
+    F: AsyncFn<T::Type<'a>, Output = Res> + Clone,
     F: AsyncFn<T>, // second bound to assist type inference to pinpoint T
 {
     type Error = Err;
     type Response = Res;
-    type Future = impl Future<Output = Result<Self::Response, Self::Error>> + 'a;
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
 
     #[inline]
     fn handle(&'a self, req: &'a mut Req) -> Self::Future {
@@ -248,7 +247,7 @@ from_req_impl! { Extract9; A, B, C, D, E, F, G, H, I }
 /// The Output type is what returns from [handler_service] function.
 pub trait Responder<'a, Req> {
     type Output;
-    type Future: Future<Output = Self::Output> + 'a;
+    type Future: Future<Output = Self::Output>;
 
     fn respond_to(self, req: &'a mut Req) -> Self::Future;
 }

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -206,23 +206,23 @@ mod test {
         }
     }
 
-    // #[tokio::test]
-    // async fn test_app() {
-    //     let state = String::from("state");
+    #[tokio::test]
+    async fn test_app() {
+        let state = String::from("state");
 
-    //     let service = App::with_current_thread_state(state)
-    //         .service(HandlerService::new(handler))
-    //         .middleware(Middleware)
-    //         .new_service(())
-    //         .await
-    //         .ok()
-    //         .unwrap();
+        let service = App::with_current_thread_state(state)
+            .service(HandlerService::new(handler))
+            .middleware(Middleware)
+            .new_service(())
+            .await
+            .ok()
+            .unwrap();
 
-    //     let req = Request::default();
+        let req = Request::default();
 
-    //     let res = service.call(req).await.unwrap();
+        let res = service.call(req).await.unwrap();
 
-    //     assert_eq!(res.status().as_u16(), 200);
-    //     assert_eq!(res.headers().get(CONTENT_TYPE).unwrap(), TEXT_UTF8);
-    // }
+        assert_eq!(res.status().as_u16(), 200);
+        assert_eq!(res.headers().get(CONTENT_TYPE).unwrap(), TEXT_UTF8);
+    }
 }

--- a/web/src/response.rs
+++ b/web/src/response.rs
@@ -12,13 +12,9 @@ use super::request::WebRequest;
 // TODO: add app state to response type.
 pub type WebResponse = Response<ResponseBody>;
 
-impl<'a, 'r, 's, S> Responder<'a, &'r mut WebRequest<'s, S>> for WebResponse
-where
-    'r: 'a,
-    's: 'a,
-{
+impl<'a, 'r, 's, S> Responder<'a, &'r mut WebRequest<'s, S>> for WebResponse {
     type Output = WebResponse;
-    type Future = impl Future<Output = Self::Output> + 'a;
+    type Future = impl Future<Output = Self::Output>;
 
     #[inline]
     fn respond_to(self, _: &'a mut &'r mut WebRequest<'s, S>) -> Self::Future {
@@ -31,11 +27,9 @@ macro_rules! text_utf8 {
         impl<'a, 'r, 's, S> Responder<'a, &'r mut WebRequest<'s, S>> for $type
         where
             S: 'static,
-            'r: 'a,
-            's: 'a,
         {
             type Output = WebResponse;
-            type Future = impl Future<Output = Self::Output> + 'a;
+            type Future = impl Future<Output = Self::Output>;
 
             fn respond_to(self, req: &'a mut &'r mut WebRequest<'s, S>) -> Self::Future {
                 async move {


### PR DESCRIPTION
HRTB reject any lifetime bounds on the quantified type.

```rust
trait Trait<T> {}

impl<'a, T> Trait<&'a T> for ()
where
  T: 'a // this bound, though always correct, is unnecessary and invalidates the HRTB `(): for<'a> Trait<&'a u8>`
{}
```
We need to always make use of implicit bounds.

For this reason, the lifetime bound on `Responder::Future` and `Handler::Future` were removed. This way the borrow checker will infer the lifetime of the future to be the minimum lifetime of all the trait input type paramters, which is correct for these traits.



