### PR TITLE
Fix ICE and simplify EnclosedFn2

### DIFF
--- a/service/src/async_closure.rs
+++ b/service/src/async_closure.rs
@@ -1,23 +1,21 @@
 use core::future::Future;
 
-pub trait AsyncClosure<'s, S, Req> {
+pub trait AsyncClosure<Args> {
     type Output;
-    type Future: Future<Output = Self::Output> + 's;
+    type Future: Future<Output = Self::Output>;
 
-    fn call(&self, service: &'s S, req: Req) -> Self::Future;
+    fn call(&self, arg: Args) -> Self::Future;
 }
 
-impl<'s, F, Fut, S, Req> AsyncClosure<'s, S, Req> for F
+impl<F, Arg1, Arg2, Fut> AsyncClosure<(Arg1, Arg2)> for F
 where
-    F: Fn(&'s S, Req) -> Fut + 's,
-    S: 's,
-    Fut: Future + 's,
-    Req: 's,
+    F: Fn(Arg1, Arg2) -> Fut,
+    Fut: Future,
 {
     type Output = Fut::Output;
-    type Future = impl Future<Output = Self::Output> + 's;
+    type Future = impl Future<Output = Self::Output>;
 
-    fn call(&self, service: &'s S, req: Req) -> Self::Future {
-        (self)(service, req)
+    fn call(&self, (arg1, arg2): (Arg1, Arg2)) -> Self::Future {
+        (self)(arg1, arg2)
     }
 }

--- a/service/src/factory/enclosed_fn.rs
+++ b/service/src/factory/enclosed_fn.rs
@@ -37,7 +37,7 @@ where
 impl<SF, Req, Arg, T, Res, Err> ServiceFactory<Req, Arg> for PipelineServiceFactory<SF, T, marker::EnclosedFn2>
 where
     SF: ServiceFactory<Req, Arg>,
-    T: for<'s> AsyncClosure<'s, SF::Service, Req, Output = Result<Res, Err>> + Clone,
+    T: for<'s> AsyncClosure<(&'s SF::Service, Req), Output = Result<Res, Err>> + Clone,
     Err: From<SF::Error>,
 {
     type Response = Res;

--- a/service/src/factory/ext.rs
+++ b/service/src/factory/ext.rs
@@ -67,7 +67,7 @@ pub trait ServiceFactoryExt<Req, Arg>: ServiceFactory<Req, Arg> {
 
     fn enclosed_fn2<T>(self, transform: T) -> PipelineServiceFactory<Self, T, marker::EnclosedFn2>
     where
-        T: for<'s> AsyncClosure<'s, Self::Service, Req> + Clone,
+        T: for<'s> AsyncClosure<(&'s Self::Service, Req)> + Clone,
         Self: ServiceFactory<Req, Arg> + Sized,
     {
         PipelineServiceFactory::new(self, transform)

--- a/service/src/ready/enclosed_fn.rs
+++ b/service/src/ready/enclosed_fn.rs
@@ -23,7 +23,7 @@ where
 impl<S, Req, T, Res, Err> ReadyService<Req> for PipelineService<S, T, marker::EnclosedFn2>
 where
     S: ReadyService<Req>,
-    T: for<'s> AsyncClosure<'s, S, Req, Output = Result<Res, Err>>,
+    T: for<'s> AsyncClosure<(&'s S, Req), Output = Result<Res, Err>>,
     Err: From<S::Error>,
 {
     type Ready = S::Ready;

--- a/service/src/service/enclosed_fn.rs
+++ b/service/src/service/enclosed_fn.rs
@@ -24,7 +24,7 @@ where
 impl<S, Req, T, Res, Err> Service<Req> for PipelineService<S, T, marker::EnclosedFn2>
 where
     S: Service<Req>,
-    T: for<'s> AsyncClosure<'s, S, Req, Output = Result<Res, Err>>,
+    T: for<'s> AsyncClosure<(&'s S, Req), Output = Result<Res, Err>>,
     Err: From<S::Error>,
 {
     type Response = Res;
@@ -33,6 +33,6 @@ where
 
     #[inline]
     fn call(&self, req: Req) -> Self::Future<'_> {
-        self.service2.call(&self.service, req)
+        self.service2.call((&self.service, req))
     }
 }


### PR DESCRIPTION
Explicit lifetime bounds on AsyncClosure can be problematic when used with HRTB.