### PR TITLE
narrow AndThen pipe service's error type.

### DIFF
--- a/http/src/util/service/context.rs
+++ b/http/src/util/service/context.rs
@@ -300,7 +300,8 @@ mod test {
         }
 
         let router = GenericRouter::with_custom_object::<super::object::ContextObjectConstructor<_, _>>()
-            .insert("/", get(fn_service(handler)));
+            .insert("/", get(fn_service(handler)))
+            .enclosed_fn(enclosed);
 
         let service = ContextBuilder::new(|| async { Ok(String::from("string_state")) })
             .service(router)

--- a/service/src/factory/and_then.rs
+++ b/service/src/factory/and_then.rs
@@ -7,11 +7,8 @@ use super::ServiceFactory;
 impl<SF, Req, SF1, Arg> ServiceFactory<Req, Arg> for PipelineT<SF, SF1, AndThen>
 where
     SF: ServiceFactory<Req, Arg>,
-
     Arg: Clone,
-
-    SF1: ServiceFactory<SF::Response, Arg>,
-    SF1::Error: From<SF::Error>,
+    SF1: ServiceFactory<SF::Response, Arg, Error = SF::Error>,
 {
     type Response = SF1::Response;
     type Error = SF1::Error;

--- a/service/src/factory/ext.rs
+++ b/service/src/factory/ext.rs
@@ -132,13 +132,17 @@ mod test {
 
     #[tokio::test]
     async fn map() {
-        let factory = fn_service(index)
-            .map(|res| {
-                let str = res?;
-                assert_eq!(str, "996");
-                Err::<(), _>(())
-            })
-            .map_err(|_| "251");
+        let factory = fn_service(index).map(|_| "251");
+
+        let service = factory.new_service(()).await.unwrap();
+
+        let err = service.call("996").await.ok().unwrap();
+        assert_eq!(err, "251");
+    }
+
+    #[tokio::test]
+    async fn map_err() {
+        let factory = fn_service(|_: &str| async { Err::<(), _>(()) }).map_err(|_| "251");
 
         let service = factory.new_service(()).await.unwrap();
 

--- a/service/src/factory/ext.rs
+++ b/service/src/factory/ext.rs
@@ -9,7 +9,7 @@ use super::{boxed::BoxedServiceFactory, ServiceFactory};
 pub trait ServiceFactoryExt<Req, Arg>: ServiceFactory<Req, Arg> {
     fn map<F, Res>(self, mapper: F) -> PipelineT<Self, F, marker::Map>
     where
-        F: Fn(Result<Self::Response, Self::Error>) -> Result<Res, Self::Error> + Clone,
+        F: Fn(Self::Response) -> Res + Clone,
         Self: Sized,
     {
         PipelineT::new(self, mapper)

--- a/service/src/factory/map.rs
+++ b/service/src/factory/map.rs
@@ -7,7 +7,7 @@ use super::ServiceFactory;
 impl<SF, Req, Arg, SF1, Res> ServiceFactory<Req, Arg> for PipelineT<SF, SF1, Map>
 where
     SF: ServiceFactory<Req, Arg>,
-    SF1: Fn(Result<SF::Response, SF::Error>) -> Result<Res, SF::Error> + Clone,
+    SF1: Fn(SF::Response) -> Res + Clone,
 {
     type Response = Res;
     type Error = SF::Error;

--- a/service/src/pipeline/pipeline_enum.rs
+++ b/service/src/pipeline/pipeline_enum.rs
@@ -19,6 +19,30 @@ where
     }
 }
 
+impl<F, S> Pipeline<F, S>
+where
+    F: From<S>,
+{
+    pub fn into_first(self) -> F {
+        match self {
+            Self::First(f) => f,
+            Self::Second(s) => F::from(s),
+        }
+    }
+}
+
+impl<F, S> Pipeline<F, S>
+where
+    S: From<F>,
+{
+    pub fn into_second(self) -> S {
+        match self {
+            Self::First(f) => S::from(f),
+            Self::Second(s) => s,
+        }
+    }
+}
+
 impl<F, S> Debug for Pipeline<F, S>
 where
     F: Debug,

--- a/service/src/ready/and_then.rs
+++ b/service/src/ready/and_then.rs
@@ -7,8 +7,7 @@ use super::ReadyService;
 impl<S, Req, S1> ReadyService<Req> for PipelineT<S, S1, AndThen>
 where
     S: ReadyService<Req>,
-    S1: ReadyService<S::Response>,
-    S1::Error: From<S::Error>,
+    S1: ReadyService<S::Response, Error = S::Error>,
 {
     type Ready = PipelineT<S::Ready, S1::Ready>;
     type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;

--- a/service/src/ready/map.rs
+++ b/service/src/ready/map.rs
@@ -5,7 +5,7 @@ use super::ReadyService;
 impl<S, Req, F, Res> ReadyService<Req> for PipelineT<S, F, Map>
 where
     S: ReadyService<Req>,
-    F: Fn(Result<S::Response, S::Error>) -> Result<Res, S::Error>,
+    F: Fn(S::Response) -> Res,
 {
     type Ready = S::Ready;
     type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;

--- a/service/src/ready/map_err.rs
+++ b/service/src/ready/map_err.rs
@@ -13,9 +13,6 @@ where
     type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
 
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async move {
-            let first = self.first.ready().await.map_err(&self.second)?;
-            Ok(first)
-        }
+        async move { self.first.ready().await.map_err(&self.second) }
     }
 }

--- a/service/src/service/and_then.rs
+++ b/service/src/service/and_then.rs
@@ -7,8 +7,7 @@ use super::Service;
 impl<S, Req, S1> Service<Req> for PipelineT<S, S1, AndThen>
 where
     S: Service<Req>,
-    S1: Service<S::Response>,
-    S1::Error: From<S::Error>,
+    S1: Service<S::Response, Error = S::Error>,
 {
     type Response = S1::Response;
     type Error = S1::Error;

--- a/service/src/service/map.rs
+++ b/service/src/service/map.rs
@@ -7,7 +7,7 @@ use super::Service;
 impl<S, Req, F, Res> Service<Req> for PipelineT<S, F, Map>
 where
     S: Service<Req>,
-    F: Fn(Result<S::Response, S::Error>) -> Result<Res, S::Error>,
+    F: Fn(S::Response) -> Res,
 {
     type Response = Res;
     type Error = S::Error;
@@ -15,9 +15,6 @@ where
 
     #[inline]
     fn call(&self, req: Req) -> Self::Future<'_> {
-        async move {
-            let res = self.first.call(req).await;
-            (self.second)(res)
-        }
+        async move { self.first.call(req).await.map(&self.second) }
     }
 }


### PR DESCRIPTION
Keep `ServiceFactoryExt::map/map_err/and_then` combinators in line with `std::result::Result`.