### PR TITLE
rework ReadyService trait.

### DIFF
--- a/http/src/h1/service.rs
+++ b/http/src/h1/service.rs
@@ -75,10 +75,10 @@ where
     B: Stream<Item = Result<Bytes, BE>>,
 {
     type Ready = S::Ready;
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async move { self.service.ready().await.map_err(HttpServiceError::Service) }
+        self.service.ready()
     }
 }

--- a/http/src/h2/service.rs
+++ b/http/src/h2/service.rs
@@ -109,10 +109,10 @@ where
     BE: fmt::Debug,
 {
     type Ready = S::Ready;
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async move { self.service.ready().await.map_err(HttpServiceError::Service) }
+        self.service.ready()
     }
 }

--- a/http/src/h3/service.rs
+++ b/http/src/h3/service.rs
@@ -52,10 +52,10 @@ where
     BE: fmt::Debug,
 {
     type Ready = S::Ready;
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = S::ReadyFuture<'f>;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async move { self.service.ready().await.map_err(HttpServiceError::Service) }
+        self.service.ready()
     }
 }

--- a/http/src/service.rs
+++ b/http/src/service.rs
@@ -187,10 +187,10 @@ where
     BE: fmt::Debug,
 {
     type Ready = S::Ready;
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async move { self.service.ready().await.map_err(HttpServiceError::Service) }
+        self.service.ready()
     }
 }

--- a/http/src/util/service/context.rs
+++ b/http/src/util/service/context.rs
@@ -174,7 +174,7 @@ where
     S: for<'c, 's> ReadyService<&'c mut Context<'s, Req, C>, Response = Res, Error = Err, Ready = R>,
 {
     type Ready = R;
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {

--- a/http/src/util/service/route.rs
+++ b/http/src/util/service/route.rs
@@ -184,11 +184,11 @@ where
     Req: BorrowReq<http::Method>,
 {
     type Ready = ();
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async { Ok(()) }
+        async {}
     }
 }
 

--- a/http/src/util/service/router.rs
+++ b/http/src/util/service/router.rs
@@ -124,11 +124,11 @@ where
     Req: BorrowReq<http::Uri>,
 {
     type Ready = ();
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where S: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async { Ok(()) }
+        async {}
     }
 }
 

--- a/server/src/worker/mod.rs
+++ b/server/src/worker/mod.rs
@@ -29,8 +29,7 @@ where
 
     tokio::task::spawn_local(async move {
         loop {
-            // TODO: What if service return Error when ready.
-            let ready = service.ready().await.ok();
+            let ready = service.ready().await;
 
             match listener.accept().await {
                 Ok(stream) => {

--- a/service/src/ready/and_then.rs
+++ b/service/src/ready/and_then.rs
@@ -10,13 +10,13 @@ where
     S1: ReadyService<S::Response, Error = S::Error>,
 {
     type Ready = PipelineT<S::Ready, S1::Ready>;
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;
 
     fn ready(&self) -> Self::ReadyFuture<'_> {
         async move {
-            let first = self.first.ready().await?;
-            let second = self.second.ready().await?;
-            Ok(PipelineT::new(first, second))
+            let first = self.first.ready().await;
+            let second = self.second.ready().await;
+            PipelineT::new(first, second)
         }
     }
 }

--- a/service/src/ready/enclosed_fn.rs
+++ b/service/src/ready/enclosed_fn.rs
@@ -1,5 +1,3 @@
-use core::future::Future;
-
 use crate::{
     async_closure::AsyncClosure,
     pipeline::{marker::EnclosedFn, PipelineT},
@@ -11,13 +9,12 @@ impl<S, Req, T, Res, Err> ReadyService<Req> for PipelineT<S, T, EnclosedFn>
 where
     S: ReadyService<Req>,
     T: for<'s> AsyncClosure<(&'s S, Req), Output = Result<Res, Err>>,
-    Err: From<S::Error>,
 {
     type Ready = S::Ready;
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async move { self.first.ready().await.map_err(Into::into) }
+        self.first.ready()
     }
 }

--- a/service/src/ready/function.rs
+++ b/service/src/ready/function.rs
@@ -10,10 +10,10 @@ where
     Fut: Future<Output = Result<Res, Err>>,
 {
     type Ready = ();
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where F: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async { Ok(()) }
+        async { () }
     }
 }

--- a/service/src/ready/function.rs
+++ b/service/src/ready/function.rs
@@ -14,6 +14,6 @@ where
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async { () }
+        async {}
     }
 }

--- a/service/src/ready/map_err.rs
+++ b/service/src/ready/map_err.rs
@@ -1,5 +1,3 @@
-use core::future::Future;
-
 use crate::pipeline::{marker::MapErr, PipelineT};
 
 use super::ReadyService;
@@ -10,9 +8,10 @@ where
     F: Fn(S::Error) -> E,
 {
     type Ready = S::Ready;
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where Self: 'f;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;
 
+    #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async move { self.first.ready().await.map_err(&self.second) }
+        self.first.ready()
     }
 }

--- a/service/src/ready/mod.rs
+++ b/service/src/ready/mod.rs
@@ -44,8 +44,8 @@ use super::service::Service;
 /// }
 ///
 /// impl ReadyService<()> for Foo {
-///     type Ready = Permit;
-///     type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>>;
+///     type Ready = Result<Permit, Self::Error>;
+///     type ReadyFuture<'f> = impl Future<Output = Self::Ready>;
 ///
 ///     fn ready(&self) -> Self::ReadyFuture<'_> {
 ///         async move {
@@ -78,7 +78,7 @@ use super::service::Service;
 pub trait ReadyService<Req>: Service<Req> {
     type Ready;
 
-    type ReadyFuture<'f>: Future<Output = Result<Self::Ready, Self::Error>>
+    type ReadyFuture<'f>: Future<Output = Self::Ready>
     where
         Self: 'f;
 
@@ -92,7 +92,7 @@ macro_rules! impl_alloc {
             S: ReadyService<Req> + ?Sized,
         {
             type Ready = S::Ready;
-            type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;
+            type ReadyFuture<'f> = S::ReadyFuture<'f> where S: 'f;
 
             #[inline]
             fn ready(&self) -> Self::ReadyFuture<'_> {
@@ -114,7 +114,7 @@ where
     type Ready = <S::Target as ReadyService<Req>>::Ready;
     type ReadyFuture<'f> = <S::Target as ReadyService<Req>>::ReadyFuture<'f>
     where
-        Self: 'f;
+        S: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {

--- a/test/tests/macro.rs
+++ b/test/tests/macro.rs
@@ -40,7 +40,7 @@ where
         Ok(TestMiddlewareService(service))
     }
 
-    async fn ready(&self) -> Result<S::Ready, Box<dyn std::error::Error>> {
+    async fn ready(&self) -> S::Ready {
         self.0.ready().await
     }
 

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -158,7 +158,7 @@ where
     S: for<'c1, 's1> ReadyService<&'c1 mut WebRequest<'s1, C>, Response = Res, Error = Err, Ready = R>,
 {
     type Ready = R;
-    type ReadyFuture<'f> = impl Future<Output = Result<Self::Ready, Self::Error>> where S: 'f;
+    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where S: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {


### PR DESCRIPTION
rework `ReadyService::Ready` type. It does not force to output Result<T, E> from the `ready` method.