### PR TITLE
ContextService pass owned typed to downstream.

### DIFF
--- a/examples/io-uring.rs
+++ b/examples/io-uring.rs
@@ -41,13 +41,13 @@ fn main() -> std::io::Result<()> {
     })
 }
 
-async fn handler(req: &mut WebRequest<'_, Rc<NamedTempFile>>) -> Result<WebResponse, Box<dyn std::error::Error>> {
+async fn handler(req: WebRequest<'_, Rc<NamedTempFile>>) -> Result<WebResponse, Box<dyn std::error::Error>> {
     let file = File::open(req.state().path()).await?;
     let res = read(&file).await;
     file.close().await?;
     let buf = res?;
 
-    let mut res = req.as_response(buf);
+    let mut res = req.into_response(buf);
     res.headers_mut().append(CONTENT_TYPE, TEXT_UTF8);
 
     Ok(res)

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -36,7 +36,7 @@ async fn main() -> std::io::Result<()> {
     .await
 }
 
-async fn handler(req: &mut WebRequest<'_, &'static str>) -> Result<WebResponse, Box<dyn std::error::Error>> {
+async fn handler(mut req: WebRequest<'_, &'static str>) -> Result<WebResponse, Box<dyn std::error::Error>> {
     // borrow shared state of App.
     let state = req.state();
     assert_eq!(*state, "app_state");

--- a/http/src/util/service/context.rs
+++ b/http/src/util/service/context.rs
@@ -246,7 +246,7 @@ mod test {
         state: &'a ST,
     }
 
-    async fn into_context<'c>(req: Context<'c, Request<()>, String>) -> Result<Context2<'c, String>, Infallible> {
+    async fn into_context(req: Context<'_, Request<()>, String>) -> Result<Context2<'_, String>, Infallible> {
         let (req, state) = req.into_parts();
         assert_eq!(state, "string_state");
         Ok(Context2 { req, state })

--- a/http/src/util/service/context.rs
+++ b/http/src/util/service/context.rs
@@ -26,8 +26,8 @@ use crate::request::{BorrowReq, BorrowReqMut};
 /// # use xitca_service::{fn_service, Service, BuildService};
 ///
 /// // function service.
-/// async fn state_handler(req: &mut Context<'_, String, String>) -> Result<String, Infallible> {
-///    let (parent_req, state) = req.borrow_parts_mut();
+/// async fn state_handler(req: Context<'_, String, String>) -> Result<String, Infallible> {
+///    let (parent_req, state) = req.into_parts();
 ///    assert_eq!(state, "string_state");
 ///    Ok(String::from("string_response"))
 /// }
@@ -91,15 +91,15 @@ pub struct Context<'a, Req, C> {
     state: &'a C,
 }
 
-impl<Req, C> Context<'_, Req, C> {
+impl<'a, Req, C> Context<'a, Req, C> {
     /// Destruct request into a tuple of (&state, parent_request).
     #[inline]
-    pub fn borrow_parts_mut(&mut self) -> (&mut Req, &C) {
-        (&mut self.req, self.state)
+    pub fn into_parts(self) -> (Req, &'a C) {
+        (self.req, self.state)
     }
 }
 
-impl<Req, C, T> BorrowReq<T> for &mut Context<'_, Req, C>
+impl<Req, C, T> BorrowReq<T> for Context<'_, Req, C>
 where
     Req: BorrowReq<T>,
 {
@@ -108,7 +108,7 @@ where
     }
 }
 
-impl<Req, C, T> BorrowReqMut<T> for &mut Context<'_, Req, C>
+impl<Req, C, T> BorrowReqMut<T> for Context<'_, Req, C>
 where
     Req: BorrowReqMut<T>,
 {
@@ -151,7 +151,7 @@ pub struct ContextService<C, S> {
 
 impl<Req, C, S, Res, Err> Service<Req> for ContextService<C, S>
 where
-    S: for<'c, 's> Service<&'c mut Context<'s, Req, C>, Response = Res, Error = Err>,
+    S: for<'c> Service<Context<'c, Req, C>, Response = Res, Error = Err>,
 {
     type Response = Res;
     type Error = Err;
@@ -160,7 +160,7 @@ where
     fn call(&self, req: Req) -> Self::Future<'_> {
         async move {
             self.service
-                .call(&mut Context {
+                .call(Context {
                     req,
                     state: &self.state,
                 })
@@ -171,7 +171,7 @@ where
 
 impl<Req, C, S, R, Res, Err> ReadyService<Req> for ContextService<C, S>
 where
-    S: for<'c, 's> ReadyService<&'c mut Context<'s, Req, C>, Response = Res, Error = Err, Ready = R>,
+    S: for<'c> ReadyService<Context<'c, Req, C>, Response = Res, Error = Err, Ready = R>,
 {
     type Ready = R;
     type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;
@@ -198,19 +198,16 @@ pub mod object {
 
     pub struct ContextObjectConstructor<Req, C>(PhantomData<(Req, C)>);
 
-    pub type ContextFactoryObject<Req: 'static, C: 'static, BErr, Res, Err> =
+    pub type ContextFactoryObject<Req, C, BErr, Res, Err> =
         impl BuildService<Error = BErr, Service = ContextServiceObject<Req, C, Res, Err>>;
 
-    pub type ContextServiceObject<Req: 'static, C: 'static, Res, Err> =
-        impl for<'c, 's> Service<&'c mut Context<'s, Req, C>, Response = Res, Error = Err>;
+    pub type ContextServiceObject<Req, C, Res, Err> =
+        impl for<'c> Service<Context<'c, Req, C>, Response = Res, Error = Err>;
 
     impl<C, I, Svc, BErr, Req, Res, Err> ObjectConstructor<I> for ContextObjectConstructor<Req, C>
     where
-        I: BuildService<Service = Svc, Error = BErr>,
-        Svc: for<'c, 's> Service<&'c mut Context<'s, Req, C>, Response = Res, Error = Err> + 'static,
-        I: 'static,
-        C: 'static,
-        Req: 'static,
+        I: BuildService<Service = Svc, Error = BErr> + 'static,
+        Svc: for<'c> Service<Context<'c, Req, C>, Response = Res, Error = Err> + 'static,
     {
         type Object = ContextFactoryObject<Req, C, BErr, Res, Err>;
 
@@ -219,7 +216,7 @@ pub mod object {
                 let fut = inner.build(());
                 async move {
                     let boxed_service = Box::new(Wrapper(fut.await?))
-                        as Box<dyn for<'c, 's> ServiceObject<&'c mut Context<'s, Req, C>, Response = _, Error = _>>;
+                        as Box<dyn for<'c> ServiceObject<Context<'c, Req, C>, Response = _, Error = _>>;
                     Ok(Wrapper(boxed_service))
                 }
             });
@@ -245,14 +242,12 @@ mod test {
     use super::*;
 
     struct Context2<'a, ST> {
-        req: &'a mut Request<()>,
+        req: Request<()>,
         state: &'a ST,
     }
 
-    async fn into_context<'c>(
-        req: &'c mut Context<'_, Request<()>, String>,
-    ) -> Result<Context2<'c, String>, Infallible> {
-        let (req, state) = req.borrow_parts_mut();
+    async fn into_context<'c>(req: Context<'c, Request<()>, String>) -> Result<Context2<'c, String>, Infallible> {
+        let (req, state) = req.into_parts();
         assert_eq!(state, "string_state");
         Ok(Context2 { req, state })
     }
@@ -279,17 +274,17 @@ mod test {
         assert_eq!(res.status().as_u16(), 200);
     }
 
-    async fn handler(req: &mut Context<'_, Request<()>, String>) -> Result<Response<()>, Infallible> {
-        let (_, state) = req.borrow_parts_mut();
+    async fn handler(req: Context<'_, Request<()>, String>) -> Result<Response<()>, Infallible> {
+        let (_, state) = req.into_parts();
         assert_eq!(state, "string_state");
         Ok(Response::new(()))
     }
 
     #[tokio::test]
     async fn test_state_in_router() {
-        async fn enclosed<S, Req, C, Res, Err>(service: &S, req: &mut Context<'_, Req, C>) -> Result<Res, Err>
+        async fn enclosed<S, Req, C, Res, Err>(service: &S, req: Context<'_, Req, C>) -> Result<Res, Err>
         where
-            S: for<'c, 's> Service<&'c mut Context<'s, Req, C>, Response = Res, Error = Err>,
+            S: for<'c> Service<Context<'c, Req, C>, Response = Res, Error = Err>,
         {
             service.call(req).await
         }

--- a/web/src/handler/impls.rs
+++ b/web/src/handler/impls.rs
@@ -6,37 +6,37 @@ use crate::{request::WebRequest, response::WebResponse};
 
 use super::{FromRequest, Responder};
 
-impl<'a, 'r, 's, S> FromRequest<'a, &'r mut WebRequest<'s, S>> for &'a WebRequest<'a, S>
+impl<'a, 'r, S> FromRequest<'a, WebRequest<'r, S>> for &'a WebRequest<'a, S>
 where
     S: 'static,
 {
     type Type<'b> = &'b WebRequest<'b, S>;
     type Error = Infallible;
-    type Future = impl Future<Output = Result<Self, Self::Error>> where &'r mut WebRequest<'s, S>: 'a;
+    type Future = impl Future<Output = Result<Self, Self::Error>> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn from_request(req: &'a &'r mut WebRequest<'s, S>) -> Self::Future {
-        async move { Ok(&**req) }
+    fn from_request(req: &'a WebRequest<'r, S>) -> Self::Future {
+        async move { Ok(&*req) }
     }
 }
 
-impl<'r, 's, S> Responder<&'r mut WebRequest<'s, S>> for WebResponse {
+impl<'r, S> Responder<WebRequest<'r, S>> for WebResponse {
     type Output = WebResponse;
-    type Future<'a> = impl Future<Output = Self::Output> where &'r mut WebRequest<'s, S>: 'a;
+    type Future<'a> = impl Future<Output = Self::Output> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn respond_to<'a>(self, _: &'a mut &'r mut WebRequest<'s, S>) -> Self::Future<'a> {
+    fn respond_to<'a>(self, _: &'a mut WebRequest<'r, S>) -> Self::Future<'a> {
         async { self }
     }
 }
 
 macro_rules! text_utf8 {
     ($type: ty) => {
-        impl<'r, 's, S: 's> Responder<&'r mut WebRequest<'s, S>> for $type {
+        impl<'r, S: 'r> Responder<WebRequest<'r, S>> for $type {
             type Output = WebResponse;
-            type Future<'a> = impl Future<Output = Self::Output> where &'r mut WebRequest<'s, S>: 'a;
+            type Future<'a> = impl Future<Output = Self::Output> where WebRequest<'r, S>: 'a;
 
-            fn respond_to<'a>(self, req: &'a mut &'r mut WebRequest<'s, S>) -> Self::Future<'a> {
+            fn respond_to<'a>(self, req: &'a mut WebRequest<'r, S>) -> Self::Future<'a> {
                 let mut res = req.as_response(self);
                 res.headers_mut().insert(CONTENT_TYPE, TEXT_UTF8);
                 async { res }

--- a/web/src/handler/types/body.rs
+++ b/web/src/handler/types/body.rs
@@ -4,13 +4,13 @@ use crate::{handler::FromRequest, request::RequestBody, request::WebRequest};
 
 pub struct Body(pub RequestBody);
 
-impl<'a, 'r, 's, S: 's> FromRequest<'a, &'r mut WebRequest<'s, S>> for Body {
+impl<'a, 'r, S: 'r> FromRequest<'a, WebRequest<'r, S>> for Body {
     type Type<'b> = Body;
     type Error = Infallible;
-    type Future = impl Future<Output = Result<Self, Self::Error>> where &'r mut WebRequest<'s, S>: 'a;
+    type Future = impl Future<Output = Result<Self, Self::Error>> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn from_request(req: &'a &'r mut WebRequest<'s, S>) -> Self::Future {
+    fn from_request(req: &'a WebRequest<'r, S>) -> Self::Future {
         let extract = Body(std::mem::take(&mut *req.body_borrow_mut()));
         async move { Ok(extract) }
     }

--- a/web/src/handler/types/extension.rs
+++ b/web/src/handler/types/extension.rs
@@ -19,16 +19,16 @@ impl<T> Deref for ExtensionRef<'_, T> {
     }
 }
 
-impl<'a, 'r, 's, S: 's, T> FromRequest<'a, &'r mut WebRequest<'s, S>> for ExtensionRef<'a, T>
+impl<'a, 'r, S: 'r, T> FromRequest<'a, WebRequest<'r, S>> for ExtensionRef<'a, T>
 where
     T: Send + Sync + 'static,
 {
     type Type<'b> = ExtensionRef<'b, T>;
     type Error = Infallible;
-    type Future = impl Future<Output = Result<Self, Self::Error>> where &'r mut WebRequest<'s, S>: 'a;
+    type Future = impl Future<Output = Result<Self, Self::Error>> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn from_request(req: &'a &'r mut WebRequest<'s, S>) -> Self::Future {
+    fn from_request(req: &'a WebRequest<'r, S>) -> Self::Future {
         async move { Ok(ExtensionRef(req.req().extensions().get::<T>().unwrap())) }
     }
 }
@@ -44,13 +44,13 @@ impl Deref for ExtensionsRef<'_> {
     }
 }
 
-impl<'a, 'r, 's, S: 's> FromRequest<'a, &'r mut WebRequest<'s, S>> for ExtensionsRef<'a> {
+impl<'a, 'r, S: 'r> FromRequest<'a, WebRequest<'r, S>> for ExtensionsRef<'a> {
     type Type<'b> = ExtensionsRef<'b>;
     type Error = Infallible;
-    type Future = impl Future<Output = Result<Self, Self::Error>> where &'r mut WebRequest<'s, S>: 'a;
+    type Future = impl Future<Output = Result<Self, Self::Error>> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn from_request(req: &'a &'r mut WebRequest<'s, S>) -> Self::Future {
+    fn from_request(req: &'a WebRequest<'r, S>) -> Self::Future {
         async move { Ok(ExtensionsRef(req.req().extensions())) }
     }
 }

--- a/web/src/handler/types/header.rs
+++ b/web/src/handler/types/header.rs
@@ -56,15 +56,13 @@ impl<const HEADER_NAME: usize> Deref for HeaderRef<'_, HEADER_NAME> {
     }
 }
 
-impl<'a, 'r, 's, S: 's, const HEADER_NAME: usize> FromRequest<'a, &'r mut WebRequest<'s, S>>
-    for HeaderRef<'a, HEADER_NAME>
-{
+impl<'a, 'r, S: 'r, const HEADER_NAME: usize> FromRequest<'a, WebRequest<'r, S>> for HeaderRef<'a, HEADER_NAME> {
     type Type<'b> = HeaderRef<'b, HEADER_NAME>;
     type Error = Infallible;
-    type Future = impl Future<Output = Result<Self, Self::Error>> where &'r mut WebRequest<'s, S>: 'a;
+    type Future = impl Future<Output = Result<Self, Self::Error>> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn from_request(req: &'a &'r mut WebRequest<'s, S>) -> Self::Future {
+    fn from_request(req: &'a WebRequest<'r, S>) -> Self::Future {
         async move {
             Ok(HeaderRef(
                 req.req().headers().get(&map_to_header_name::<HEADER_NAME>()).unwrap(),
@@ -90,7 +88,8 @@ mod test {
 
     #[tokio::test]
     async fn extract_header() {
-        let mut req = WebRequest::with_state(&());
+        let mut req = WebRequest::new_test(());
+        let mut req = req.as_web_req();
         req.req_mut()
             .headers_mut()
             .insert(header::HOST, header::HeaderValue::from_static("996"));
@@ -99,7 +98,7 @@ mod test {
             .insert(header::ACCEPT_ENCODING, header::HeaderValue::from_static("251"));
 
         assert_eq!(
-            HeaderRef::<'_, { super::ACCEPT_ENCODING }>::from_request(&&mut req)
+            HeaderRef::<'_, { super::ACCEPT_ENCODING }>::from_request(&req)
                 .await
                 .unwrap()
                 .try_parse::<String>()
@@ -107,7 +106,7 @@ mod test {
             "251"
         );
         assert_eq!(
-            HeaderRef::<'_, { super::HOST }>::from_request(&&mut req)
+            HeaderRef::<'_, { super::HOST }>::from_request(&req)
                 .await
                 .unwrap()
                 .try_parse::<String>()

--- a/web/src/handler/types/html.rs
+++ b/web/src/handler/types/html.rs
@@ -20,15 +20,15 @@ where
     }
 }
 
-impl<'r, 's, S, T> Responder<&'r mut WebRequest<'s, S>> for Html<T>
+impl<'r, S: 'r, T> Responder<WebRequest<'r, S>> for Html<T>
 where
     T: Into<ResponseBody>,
 {
     type Output = WebResponse;
-    type Future<'a> = impl Future<Output = Self::Output> where &'r mut WebRequest<'s, S>: 'a;
+    type Future<'a> = impl Future<Output = Self::Output> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn respond_to<'a>(self, req: &'a mut &'r mut WebRequest<'s, S>) -> Self::Future<'a> {
+    fn respond_to<'a>(self, req: &'a mut WebRequest<'r, S>) -> Self::Future<'a> {
         let mut res = req.as_response(self.0);
         res.headers_mut().insert(CONTENT_TYPE, TEXT_HTML_UTF8);
         async { res }

--- a/web/src/handler/types/path.rs
+++ b/web/src/handler/types/path.rs
@@ -13,13 +13,13 @@ impl Deref for PathRef<'_> {
     }
 }
 
-impl<'a, 'r, 's, S: 's> FromRequest<'a, &'r mut WebRequest<'s, S>> for PathRef<'a> {
+impl<'a, 'r, S: 'r> FromRequest<'a, WebRequest<'r, S>> for PathRef<'a> {
     type Type<'b> = PathRef<'b>;
     type Error = Infallible;
-    type Future = impl Future<Output = Result<Self, Self::Error>> where &'r mut WebRequest<'s, S>: 'a;
+    type Future = impl Future<Output = Result<Self, Self::Error>> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn from_request(req: &'a &'r mut WebRequest<'s, S>) -> Self::Future {
+    fn from_request(req: &'a WebRequest<'r, S>) -> Self::Future {
         async move { Ok(PathRef(req.req().uri().path())) }
     }
 }

--- a/web/src/handler/types/request.rs
+++ b/web/src/handler/types/request.rs
@@ -13,13 +13,13 @@ impl Deref for RequestRef<'_> {
     }
 }
 
-impl<'a, 'r, 's, S: 's> FromRequest<'a, &'r mut WebRequest<'s, S>> for RequestRef<'a> {
+impl<'a, 'r, S: 'r> FromRequest<'a, WebRequest<'r, S>> for RequestRef<'a> {
     type Type<'b> = RequestRef<'b>;
     type Error = Infallible;
-    type Future = impl Future<Output = Result<Self, Self::Error>> where &'r mut WebRequest<'s, S>: 'a;
+    type Future = impl Future<Output = Result<Self, Self::Error>> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn from_request(req: &'a &'r mut WebRequest<'s, S>) -> Self::Future {
+    fn from_request(req: &'a WebRequest<'r, S>) -> Self::Future {
         async move { Ok(RequestRef(req.req())) }
     }
 }

--- a/web/src/handler/types/state.rs
+++ b/web/src/handler/types/state.rs
@@ -26,16 +26,16 @@ impl<S> Deref for StateRef<'_, S> {
     }
 }
 
-impl<'a, 'r, 's, S> FromRequest<'a, &'r mut WebRequest<'s, S>> for StateRef<'a, S>
+impl<'a, 'r, S> FromRequest<'a, WebRequest<'r, S>> for StateRef<'a, S>
 where
     S: 'static,
 {
     type Type<'b> = StateRef<'b, S>;
     type Error = Infallible;
-    type Future = impl Future<Output = Result<Self, Self::Error>> where &'r mut WebRequest<'s, S>: 'a;
+    type Future = impl Future<Output = Result<Self, Self::Error>> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn from_request(req: &'a &'r mut WebRequest<'s, S>) -> Self::Future {
+    fn from_request(req: &'a WebRequest<'r, S>) -> Self::Future {
         async move { Ok(StateRef(req.state())) }
     }
 }

--- a/web/src/handler/types/uri.rs
+++ b/web/src/handler/types/uri.rs
@@ -13,16 +13,16 @@ impl Deref for UriRef<'_> {
     }
 }
 
-impl<'a, 'r, 's, S> FromRequest<'a, &'r mut WebRequest<'s, S>> for UriRef<'a>
+impl<'a, 'r, S> FromRequest<'a, WebRequest<'r, S>> for UriRef<'a>
 where
     S: 'static,
 {
     type Type<'b> = UriRef<'b>;
     type Error = Infallible;
-    type Future = impl Future<Output = Result<Self, Self::Error>> where &'r mut WebRequest<'s, S>: 'a;
+    type Future = impl Future<Output = Result<Self, Self::Error>> where WebRequest<'r, S>: 'a;
 
     #[inline]
-    fn from_request(req: &'a &'r mut WebRequest<'s, S>) -> Self::Future {
+    fn from_request(req: &'a WebRequest<'r, S>) -> Self::Future {
         async move { Ok(UriRef(req.req().uri())) }
     }
 }


### PR DESCRIPTION
ContexService would pass `Context<'_, Req, C>` to it's child service.
`WebRequest` is made to a copy type and pass to web services as copied value instead of as `&mut WebRequest`.