### PR TITLE
web: fix state inference problem

### DIFF
--- a/http/src/util/service/handler.rs
+++ b/http/src/util/service/handler.rs
@@ -16,11 +16,7 @@ use xitca_service::{BuildService, Service};
 ///
 /// Given async function's return type must impl [Responder] trait for transforming arbitrary return type to `Service::Future`'s
 /// output type.
-pub fn handler_service<F, Req, T, O, Res, Err>(func: F) -> HandlerService<F, T, O, Res, Err>
-where
-    F: for<'a> Handler<'a, Req, T, Response = O, Error = Err>,
-    O: Responder<Req, Output = Res>,
-{
+pub fn handler_service<F, T, O, Res, Err>(func: F) -> HandlerService<F, T, O, Res, Err> {
     HandlerService::new(func)
 }
 
@@ -30,11 +26,7 @@ pub struct HandlerService<F, T, O, Res, Err> {
 }
 
 impl<F, T, O, Res, Err> HandlerService<F, T, O, Res, Err> {
-    pub fn new<Req>(func: F) -> Self
-    where
-        F: for<'a> Handler<'a, Req, T, Response = O, Error = Err>,
-        O: Responder<Req, Output = Res>,
-    {
+    pub fn new(func: F) -> Self {
         Self { func, _p: PhantomData }
     }
 }

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -205,6 +205,11 @@ mod test {
         state.to_string()
     }
 
+    // Handler with no state extractor
+    async fn stateless_handler(_: PathRef<'_>) -> String {
+        String::from("debug")
+    }
+
     #[derive(Clone)]
     struct Middleware;
 
@@ -254,6 +259,10 @@ mod test {
 
         let service = App::with_current_thread_state(state)
             .at("/", get(handler_service(handler)))
+            .at(
+                "/stateless",
+                get(handler_service(stateless_handler)).head(handler_service(stateless_handler)),
+            )
             .enclosed_fn(middleware_fn)
             .enclosed(Middleware)
             .finish()


### PR DESCRIPTION
Don't require `Req` to be inferred in `hander_service` and `Ruote` methods.