### PR TITLE
rework ReadyService trait.

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -142,11 +142,11 @@ pub fn middleware_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }) => quote! {
             #base
 
-            impl<#generic_ty> ::xitca_service::ready::ReadyService<#req_ty> for #service_ty
+            impl<#generic_ty> ::xitca_service::ready::ReadyService for #service_ty
             #where_clause
             {
                 type Ready = #ready_res_ty;
-                type ReadyFuture<'f> = impl ::core::future::Future<Output = Self::Ready> where Self: 'f ;
+                type ReadyFuture<'f> = impl ::core::future::Future<Output = Self::Ready> where Self: 'f;
                 #[inline]
                 fn ready(&self) -> Self::ReadyFuture<'_> {
                     async move {

--- a/http/src/h1/service.rs
+++ b/http/src/h1/service.rs
@@ -60,9 +60,9 @@ where
 }
 
 impl<St, S, B, BE, A, TlsSt, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIMIT: usize>
-    ReadyService<St> for H1Service<St, S, A, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
+    ReadyService for H1Service<St, S, A, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
 where
-    S: ReadyService<Request<RequestBody>, Response = Response<B>> + 'static,
+    S: ReadyService + Service<Request<RequestBody>, Response = Response<B>> + 'static,
 
     A: Service<St, Response = TlsSt> + 'static,
     St: AsyncIo,

--- a/http/src/h2/service.rs
+++ b/http/src/h2/service.rs
@@ -95,9 +95,9 @@ impl<
         const HEADER_LIMIT: usize,
         const READ_BUF_LIMIT: usize,
         const WRITE_BUF_LIMIT: usize,
-    > ReadyService<St> for H2Service<St, S, A, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
+    > ReadyService for H2Service<St, S, A, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
 where
-    S: ReadyService<Request<RequestBody>, Response = Response<ResB>> + 'static,
+    S: ReadyService + Service<Request<RequestBody>, Response = Response<ResB>> + 'static,
     S::Error: fmt::Debug,
 
     A: Service<St, Response = TlsSt> + 'static,

--- a/http/src/h3/service.rs
+++ b/http/src/h3/service.rs
@@ -43,16 +43,12 @@ where
     }
 }
 
-impl<S, ResB, BE> ReadyService<UdpStream> for H3Service<S>
+impl<S> ReadyService for H3Service<S>
 where
-    S: ReadyService<Request<RequestBody>, Response = Response<ResB>> + 'static,
-    S::Error: fmt::Debug,
-
-    ResB: Stream<Item = Result<Bytes, BE>>,
-    BE: fmt::Debug,
+    S: ReadyService,
 {
     type Ready = S::Ready;
-    type ReadyFuture<'f> = S::ReadyFuture<'f>;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where S: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {

--- a/http/src/service.rs
+++ b/http/src/service.rs
@@ -180,11 +180,10 @@ where
     }
 }
 
-impl<S, ResB, BE, A, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIMIT: usize>
-    ReadyService<ServerStream>
+impl<S, ResB, BE, A, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIMIT: usize> ReadyService
     for HttpService<ServerStream, S, RequestBody, A, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
 where
-    S: ReadyService<Request<RequestBody>, Response = Response<ResB>> + 'static,
+    S: ReadyService + Service<Request<RequestBody>, Response = Response<ResB>> + 'static,
     A: Service<TcpStream> + 'static,
     A::Response: AsyncIo + AsVersion + AsyncRead + AsyncWrite + Unpin,
     HttpServiceError<S::Error, BE>: From<A::Error>,

--- a/http/src/util/middleware/extension.rs
+++ b/http/src/util/middleware/extension.rs
@@ -87,10 +87,9 @@ where
     }
 }
 
-impl<S, Req, St> ReadyService<Req> for ExtensionService<S, St>
+impl<S, St> ReadyService for ExtensionService<S, St>
 where
-    S: ReadyService<Req>,
-    Req: BorrowReqMut<http::Extensions>,
+    S: ReadyService,
     St: Send + Sync + Clone + 'static,
 {
     type Ready = S::Ready;

--- a/http/src/util/middleware/logger.rs
+++ b/http/src/util/middleware/logger.rs
@@ -94,10 +94,9 @@ impl<T: Future> Future for Instrumented<'_, T> {
     }
 }
 
-impl<S, Req> ReadyService<Req> for LoggerService<S>
+impl<S> ReadyService for LoggerService<S>
 where
-    S: ReadyService<Req>,
-    S::Error: Debug,
+    S: ReadyService,
 {
     type Ready = S::Ready;
 

--- a/http/src/util/middleware/tcp_config.rs
+++ b/http/src/util/middleware/tcp_config.rs
@@ -86,9 +86,9 @@ where
     }
 }
 
-impl<S> ReadyService<TcpStream> for TcpConfigService<S>
+impl<S> ReadyService for TcpConfigService<S>
 where
-    S: ReadyService<TcpStream>,
+    S: ReadyService,
 {
     type Ready = S::Ready;
     type ReadyFuture<'f> = S::ReadyFuture<'f> where S: 'f;
@@ -116,19 +116,6 @@ where
         }
 
         self.service.call(req)
-    }
-}
-
-impl<S> ReadyService<ServerStream> for TcpConfigService<S>
-where
-    S: ReadyService<ServerStream>,
-{
-    type Ready = S::Ready;
-    type ReadyFuture<'f> = S::ReadyFuture<'f> where S: 'f;
-
-    #[inline]
-    fn ready(&self) -> Self::ReadyFuture<'_> {
-        self.service.ready()
     }
 }
 

--- a/http/src/util/service/context_priv.rs
+++ b/http/src/util/service/context_priv.rs
@@ -164,12 +164,12 @@ where
     }
 }
 
-impl<Req, C, S, R, Res, Err> ReadyService<Req> for ContextService<C, S>
+impl<C, S> ReadyService for ContextService<C, S>
 where
-    S: for<'c> ReadyService<Context<'c, Req, C>, Response = Res, Error = Err, Ready = R>,
+    S: ReadyService,
 {
-    type Ready = R;
-    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;
+    type Ready = S::Ready;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {

--- a/http/src/util/service/route.rs
+++ b/http/src/util/service/route.rs
@@ -192,10 +192,7 @@ where
     }
 }
 
-impl<Req, R, N, const M: usize> ReadyService<Req> for Route<R, N, M>
-where
-    Self: Service<Req>,
-{
+impl<R, N, const M: usize> ReadyService for Route<R, N, M> {
     type Ready = ();
     type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;
 

--- a/http/src/util/service/router_priv.rs
+++ b/http/src/util/service/router_priv.rs
@@ -154,11 +154,7 @@ where
     }
 }
 
-impl<S, Req> ReadyService<Req> for RouterService<S>
-where
-    S: Service<Req>,
-    Req: BorrowReq<http::Uri>,
-{
+impl<S> ReadyService for RouterService<S> {
     type Ready = ();
     type ReadyFuture<'f> = impl Future<Output = Self::Ready> where S: 'f;
 

--- a/server/src/server/service.rs
+++ b/server/src/server/service.rs
@@ -8,7 +8,7 @@ use std::{
 
 use tokio::task::JoinHandle;
 use xitca_io::net::{Listener, Stream};
-use xitca_service::{ready::ReadyService, BuildService};
+use xitca_service::{ready::ReadyService, BuildService, Service};
 
 use crate::worker::{self, ServiceAny};
 
@@ -44,7 +44,7 @@ pub(crate) trait _BuildService: Send + Sync {
 impl<F, Req> _BuildService for Factory<F, Req>
 where
     F: BuildServiceSync<Req>,
-    F::Service: ReadyService<Req>,
+    F::Service: ReadyService + Service<Req>,
     Req: From<Stream> + Send + 'static,
 {
     fn _build<'s, 'f>(
@@ -78,7 +78,7 @@ where
     Self: Send + Sync + 'static,
 {
     type BuildService: BuildService<Service = Self::Service>;
-    type Service: ReadyService<Req>;
+    type Service: ReadyService + Service<Req>;
 
     fn build(&self) -> Self::BuildService;
 }
@@ -87,7 +87,7 @@ impl<F, T, Req> BuildServiceSync<Req> for F
 where
     F: Fn() -> T + Send + Sync + 'static,
     T: BuildService,
-    T::Service: ReadyService<Req>,
+    T::Service: ReadyService + Service<Req>,
     Req: From<Stream>,
 {
     type BuildService = T;

--- a/server/src/worker/mod.rs
+++ b/server/src/worker/mod.rs
@@ -12,7 +12,7 @@ use std::{
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{error, info};
 use xitca_io::net::{Listener, Stream};
-use xitca_service::ready::ReadyService;
+use xitca_service::{ready::ReadyService, Service};
 
 use self::shutdown::ShutdownHandle;
 
@@ -21,7 +21,7 @@ pub(crate) type ServiceAny = Rc<dyn Any>;
 
 pub(crate) fn start<S, Req>(listener: &Arc<Listener>, service: &S) -> JoinHandle<()>
 where
-    S: ReadyService<Req> + Clone + 'static,
+    S: ReadyService + Service<Req> + Clone + 'static,
     S::Ready: 'static,
     Req: From<Stream>,
 {

--- a/service/src/build/enclosed_fn.rs
+++ b/service/src/build/enclosed_fn.rs
@@ -4,12 +4,12 @@ use crate::pipeline::{marker::EnclosedFn, PipelineT};
 
 use super::BuildService;
 
-impl<SF, Arg, T, Req> BuildService<Arg> for PipelineT<SF, T, EnclosedFn<Req>>
+impl<SF, Arg, T> BuildService<Arg> for PipelineT<SF, T, EnclosedFn>
 where
     SF: BuildService<Arg>,
     T: Clone,
 {
-    type Service = PipelineT<SF::Service, T, EnclosedFn<Req>>;
+    type Service = PipelineT<SF::Service, T, EnclosedFn>;
     type Error = SF::Error;
     type Future = impl Future<Output = Result<Self::Service, Self::Error>>;
 

--- a/service/src/build/ext.rs
+++ b/service/src/build/ext.rs
@@ -55,7 +55,7 @@ pub trait BuildServiceExt<Arg>: BuildService<Arg> {
     }
 
     /// Function version of [Self::enclosed] method.
-    fn enclosed_fn<T, Req, Req2>(self, func: T) -> PipelineT<Self, T, marker::EnclosedFn<Req2>>
+    fn enclosed_fn<T, Req>(self, func: T) -> PipelineT<Self, T, marker::EnclosedFn>
     where
         T: for<'s> AsyncClosure<(&'s Self::Service, Req)> + Clone,
         Self: BuildService<Arg> + Sized,

--- a/service/src/middleware/unchecked_ready.rs
+++ b/service/src/middleware/unchecked_ready.rs
@@ -37,10 +37,7 @@ where
     }
 }
 
-impl<S, Req> ReadyService<Req> for UncheckedReadyService<S>
-where
-    S: Service<Req>,
-{
+impl<S> ReadyService for UncheckedReadyService<S> {
     type Ready = ();
 
     type ReadyFuture<'f> = impl Future<Output = Self::Ready>

--- a/service/src/pipeline/marker.rs
+++ b/service/src/pipeline/marker.rs
@@ -1,9 +1,7 @@
 //! Marker types for different variant of [crate::pipeline::PipelineT]
 
-use core::marker::PhantomData;
-
 pub struct Map;
 pub struct MapErr;
 pub struct AndThen;
 pub struct Enclosed;
-pub struct EnclosedFn<Req>(PhantomData<Req>);
+pub struct EnclosedFn;

--- a/service/src/pipeline/mod.rs
+++ b/service/src/pipeline/mod.rs
@@ -7,7 +7,7 @@ pub use pipeline_enum::Pipeline as PipelineE;
 pub use pipeline_struct::Pipeline as PipelineT;
 
 /// Type alias for specialized [PipelineT] type with [marker::EnclosedFn].
-pub type EnclosedFnFactory<F, S, Req> = PipelineT<F, S, marker::EnclosedFn<Req>>;
+pub type EnclosedFnFactory<F, S> = PipelineT<F, S, marker::EnclosedFn>;
 
 /// Type alias for specialized [PipelineT] type with [marker::Enclosed].
 pub type EnclosedFactory<F, S> = PipelineT<F, S, marker::Enclosed>;

--- a/service/src/ready/and_then.rs
+++ b/service/src/ready/and_then.rs
@@ -4,10 +4,10 @@ use crate::pipeline::{marker::AndThen, PipelineT};
 
 use super::ReadyService;
 
-impl<S, Req, S1> ReadyService<Req> for PipelineT<S, S1, AndThen>
+impl<S, S1> ReadyService for PipelineT<S, S1, AndThen>
 where
-    S: ReadyService<Req>,
-    S1: ReadyService<S::Response, Error = S::Error>,
+    S: ReadyService,
+    S1: ReadyService,
 {
     type Ready = PipelineT<S::Ready, S1::Ready>;
     type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;

--- a/service/src/ready/enclosed_fn.rs
+++ b/service/src/ready/enclosed_fn.rs
@@ -1,14 +1,10 @@
-use crate::{
-    async_closure::AsyncClosure,
-    pipeline::{marker::EnclosedFn, PipelineT},
-};
+use crate::pipeline::{marker::EnclosedFn, PipelineT};
 
 use super::ReadyService;
 
-impl<S, Req, Req2, T, Res, Err> ReadyService<Req> for PipelineT<S, T, EnclosedFn<Req2>>
+impl<S, T> ReadyService for PipelineT<S, T, EnclosedFn>
 where
-    S: ReadyService<Req2>,
-    T: for<'s> AsyncClosure<(&'s S, Req), Output = Result<Res, Err>>,
+    S: ReadyService,
 {
     type Ready = S::Ready;
     type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;

--- a/service/src/ready/function.rs
+++ b/service/src/ready/function.rs
@@ -4,10 +4,9 @@ use crate::build::function::FnService;
 
 use super::ReadyService;
 
-impl<F, Req, Fut, Res, Err> ReadyService<Req> for FnService<F>
+impl<F> ReadyService for FnService<F>
 where
-    F: Fn(Req) -> Fut + Clone,
-    Fut: Future<Output = Result<Res, Err>>,
+    F: Clone,
 {
     type Ready = ();
     type ReadyFuture<'f> = impl Future<Output = Self::Ready> where F: 'f;

--- a/service/src/ready/map.rs
+++ b/service/src/ready/map.rs
@@ -2,10 +2,9 @@ use crate::pipeline::{marker::Map, PipelineT};
 
 use super::ReadyService;
 
-impl<S, Req, F, Res> ReadyService<Req> for PipelineT<S, F, Map>
+impl<S, F> ReadyService for PipelineT<S, F, Map>
 where
-    S: ReadyService<Req>,
-    F: Fn(S::Response) -> Res,
+    S: ReadyService,
 {
     type Ready = S::Ready;
     type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;

--- a/service/src/ready/map_err.rs
+++ b/service/src/ready/map_err.rs
@@ -2,10 +2,9 @@ use crate::pipeline::{marker::MapErr, PipelineT};
 
 use super::ReadyService;
 
-impl<S, Req, F, E> ReadyService<Req> for PipelineT<S, F, MapErr>
+impl<S, F> ReadyService for PipelineT<S, F, MapErr>
 where
-    S: ReadyService<Req>,
-    F: Fn(S::Error) -> E,
+    S: ReadyService,
 {
     type Ready = S::Ready;
     type ReadyFuture<'f> = S::ReadyFuture<'f> where Self: 'f;

--- a/service/src/service/enclosed_fn.rs
+++ b/service/src/service/enclosed_fn.rs
@@ -7,9 +7,8 @@ use crate::{
 
 use super::Service;
 
-impl<S, Req, Req2, T, Res, Err> Service<Req> for PipelineT<S, T, EnclosedFn<Req2>>
+impl<S, Req, T, Res, Err> Service<Req> for PipelineT<S, T, EnclosedFn>
 where
-    S: Service<Req2>,
     T: for<'s> AsyncClosure<(&'s S, Req), Output = Result<Res, Err>>,
 {
     type Response = Res;

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -29,7 +29,7 @@ pub fn test_server<F, T, Req>(factory: F) -> Result<TestServerHandle, Error>
 where
     F: Fn() -> T + Send + Sync + 'static,
     T: BuildService,
-    T::Service: ReadyService<Req>,
+    T::Service: ReadyService + Service<Req>,
     Req: From<NetStream> + Send + 'static,
 {
     let lst = TcpListener::bind("127.0.0.1:0")?;
@@ -51,7 +51,7 @@ pub fn test_h1_server<F, I, B, E>(factory: F) -> Result<TestServerHandle, Error>
 where
     F: Fn() -> I + Send + Sync + 'static,
     I: BuildService + 'static,
-    I::Service: ReadyService<Request<h1::RequestBody>, Response = HResponse<B>> + 'static,
+    I::Service: ReadyService + Service<Request<h1::RequestBody>, Response = HResponse<B>> + 'static,
     <I::Service as Service<Request<h1::RequestBody>>>::Error: fmt::Debug,
     I::Error: error::Error + 'static,
     B: Stream<Item = Result<Bytes, E>> + 'static,
@@ -68,7 +68,7 @@ pub fn test_h2_server<F, I, B, E>(factory: F) -> Result<TestServerHandle, Error>
 where
     F: Fn() -> I + Send + Sync + 'static,
     I: BuildService + 'static,
-    I::Service: ReadyService<Request<h2::RequestBody>, Response = HResponse<B>> + 'static,
+    I::Service: ReadyService + Service<Request<h2::RequestBody>, Response = HResponse<B>> + 'static,
     <I::Service as Service<Request<h2::RequestBody>>>::Error: fmt::Debug,
     I::Error: error::Error + 'static,
     B: Stream<Item = Result<Bytes, E>> + 'static,
@@ -89,7 +89,7 @@ pub fn test_h3_server<F, I, B, E>(factory: F) -> Result<TestServerHandle, Error>
 where
     F: Fn() -> I + Send + Sync + 'static,
     I: BuildService + 'static,
-    I::Service: ReadyService<Request<h3::RequestBody>, Response = HResponse<B>> + 'static,
+    I::Service: ReadyService + Service<Request<h3::RequestBody>, Response = HResponse<B>> + 'static,
     <I::Service as Service<Request<h3::RequestBody>>>::Error: fmt::Debug,
     I::Error: error::Error + 'static,
     B: Stream<Item = Result<Bytes, E>> + 'static,

--- a/test/tests/macro.rs
+++ b/test/tests/macro.rs
@@ -34,7 +34,7 @@ struct TestMiddlewareService<S>(S);
 #[xitca_codegen::middleware_impl]
 impl<S> TestMiddlewareService<S>
 where
-    S: ReadyService<String, Error = Box<dyn std::error::Error>, Response = usize>,
+    S: ReadyService + Service<String, Error = Box<dyn std::error::Error>, Response = usize>,
 {
     async fn new_service(_m: &TestMiddleware, service: S) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(TestMiddlewareService(service))

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -108,7 +108,7 @@ where
     }
 
     /// Enclose App with function as middleware type.
-    pub fn enclosed_fn<Req, Req2, T>(self, transform: T) -> App<CF, EnclosedFnFactory<R, T, Req2>>
+    pub fn enclosed_fn<Req, T>(self, transform: T) -> App<CF, EnclosedFnFactory<R, T>>
     where
         T: for<'s> AsyncClosure<(&'s R::Service, Req)> + Clone,
     {
@@ -119,10 +119,10 @@ where
     }
 
     /// Finish App build. No other App method can be called afterwards.
-    pub fn finish<C, Fut, CErr, ReqB, ResB, E, Err, Rdy>(
+    pub fn finish<C, Fut, CErr, ReqB, ResB, E, Err>(
         self,
     ) -> impl BuildService<
-        Service = impl ReadyService<Request<ReqB>, Response = WebResponse<ResponseBody<ResB>>, Error = Err, Ready = Rdy>,
+        Service = impl ReadyService + Service<Request<ReqB>, Response = WebResponse<ResponseBody<ResB>>, Error = Err>,
         Error = impl fmt::Debug,
     >
     where
@@ -131,8 +131,7 @@ where
         C: 'static,
         CErr: fmt::Debug,
         ReqB: 'static,
-        R::Service:
-            for<'r> ReadyService<WebRequest<'r, C, ReqB>, Response = WebResponse<ResB>, Error = Err, Ready = Rdy>,
+        R::Service: ReadyService + for<'r> Service<WebRequest<'r, C, ReqB>, Response = WebResponse<ResB>, Error = Err>,
         R::Error: fmt::Debug,
         Err: for<'r> Responder<WebRequest<'r, C, ReqB>, Output = WebResponse>,
         ResB: Stream<Item = Result<Bytes, E>>,

--- a/web/src/middleware/compress.rs
+++ b/web/src/middleware/compress.rs
@@ -49,18 +49,15 @@ where
     }
 }
 
-impl<'r, S, C, ReqB, ResB, Err, Rdy> ReadyService<WebRequest<'r, C, ReqB>> for CompressService<S>
+impl<S> ReadyService for CompressService<S>
 where
-    C: 'static,
-    ReqB: 'static,
-    S: for<'rs> ReadyService<WebRequest<'rs, C, ReqB>, Response = WebResponse<ResB>, Error = Err, Ready = Rdy>,
-    ResB: WebStream,
+    S: ReadyService,
 {
-    type Ready = Rdy;
-    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;
+    type Ready = S::Ready;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where S: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async move { self.service.ready().await }
+        self.service.ready()
     }
 }

--- a/web/src/middleware/decompress.rs
+++ b/web/src/middleware/decompress.rs
@@ -58,18 +58,16 @@ where
     }
 }
 
-impl<'r, S, C, B, Res, Err, Rdy> ReadyService<WebRequest<'r, C, B>> for DecompressService<S>
+impl<S> ReadyService for DecompressService<S>
 where
-    C: 'static,
-    B: WebStream + Default + 'static,
-    S: for<'rs> ReadyService<WebRequest<'rs, C, Coder<B>>, Response = Res, Error = Err, Ready = Rdy>,
+    S: ReadyService,
 {
-    type Ready = Rdy;
-    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;
+    type Ready = S::Ready;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where S: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async move { self.service.ready().await }
+        self.service.ready()
     }
 }
 

--- a/web/src/middleware/limit.rs
+++ b/web/src/middleware/limit.rs
@@ -84,18 +84,16 @@ where
     }
 }
 
-impl<'r, S, C, B, Res, Err, Rdy> ReadyService<WebRequest<'r, C, B>> for LimitService<S>
+impl<S> ReadyService for LimitService<S>
 where
-    C: 'static,
-    B: WebStream + Default + 'static,
-    S: for<'rs> ReadyService<WebRequest<'rs, C, LimitBody<B>>, Response = Res, Error = Err, Ready = Rdy>,
+    S: ReadyService,
 {
-    type Ready = Rdy;
-    type ReadyFuture<'f> = impl Future<Output = Self::Ready> where Self: 'f;
+    type Ready = S::Ready;
+    type ReadyFuture<'f> = S::ReadyFuture<'f> where S: 'f;
 
     #[inline]
     fn ready(&self) -> Self::ReadyFuture<'_> {
-        async { self.service.ready().await }
+        self.service.ready()
     }
 }
 

--- a/web/src/server.rs
+++ b/web/src/server.rs
@@ -200,7 +200,7 @@ where
     pub fn bind<A: ToSocketAddrs, ResB, BE>(mut self, addr: A) -> std::io::Result<Self>
     where
         I: BuildService + 'static,
-        I::Service: ReadyService<Request<RequestBody>, Response = Response<ResB>> + 'static,
+        I::Service: ReadyService + Service<Request<RequestBody>, Response = Response<ResB>> + 'static,
         <I::Service as Service<Request<RequestBody>>>::Error: fmt::Debug,
 
         ResB: Stream<Item = Result<Bytes, BE>> + 'static,
@@ -224,7 +224,7 @@ where
     ) -> std::io::Result<Self>
     where
         I: BuildService + 'static,
-        I::Service: ReadyService<Request<RequestBody>, Response = Response<ResB>> + 'static,
+        I::Service: ReadyService + Service<Request<RequestBody>, Response = Response<ResB>> + 'static,
         <I::Service as Service<Request<RequestBody>>>::Error: fmt::Debug,
 
         ResB: Stream<Item = Result<Bytes, BE>> + 'static,
@@ -280,7 +280,7 @@ where
     ) -> std::io::Result<Self>
     where
         I: BuildService + 'static,
-        I::Service: ReadyService<Request<RequestBody>, Response = Response<ResB>> + 'static,
+        I::Service: ReadyService + Service<Request<RequestBody>, Response = Response<ResB>> + 'static,
         <I::Service as Service<Request<RequestBody>>>::Error: fmt::Debug,
 
         ResB: Stream<Item = Result<Bytes, BE>> + 'static,
@@ -313,7 +313,7 @@ where
     pub fn bind_unix<P: AsRef<std::path::Path>, ResB, BE>(mut self, path: P) -> std::io::Result<Self>
     where
         I: BuildService + 'static,
-        I::Service: ReadyService<Request<RequestBody>, Response = Response<ResB>> + 'static,
+        I::Service: ReadyService + Service<Request<RequestBody>, Response = Response<ResB>> + 'static,
         <I::Service as Service<Request<RequestBody>>>::Error: fmt::Debug,
 
         ResB: Stream<Item = Result<Bytes, BE>> + 'static,


### PR DESCRIPTION
Decouple `Service` and `ReadyService` traits completely. This would improve type inference for `BuildServiceExt::enclosed_fn` and possible replace all combinator methods with it.