### PR TITLE
add head method support to http-file.

### DIFF
--- a/http-file/src/error.rs
+++ b/http-file/src/error.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use std::{error, io};
 
-use http::{request::Parts, Request, Response, StatusCode};
+use http::{header::ALLOW, request::Parts, HeaderValue, Request, Response, StatusCode};
 
 /// high level error types for serving file.
 /// see [into_response_from] and [into_response] for way of converting error to [Response] type.
@@ -62,7 +62,10 @@ impl ServeError {
 
     fn _into_response(self, mut res: Response<()>) -> Response<()> {
         match self {
-            Self::MethodNotAllowed => *res.status_mut() = StatusCode::METHOD_NOT_ALLOWED,
+            Self::MethodNotAllowed => {
+                *res.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+                res.headers_mut().insert(ALLOW, HeaderValue::from_static("GET,HEAD"));
+            }
             Self::InvalidPath => *res.status_mut() = StatusCode::BAD_REQUEST,
             Self::NotModified => *res.status_mut() = StatusCode::NOT_MODIFIED,
             Self::PreconditionFailed => *res.status_mut() = StatusCode::PRECONDITION_FAILED,

--- a/http-file/src/runtime.rs
+++ b/http-file/src/runtime.rs
@@ -6,7 +6,7 @@ use bytes::BytesMut;
 
 /// trait for generic over async file systems.
 pub trait AsyncFs: Clone {
-    type File: ChunkRead;
+    type File: ChunkRead + Meta;
     type OpenFuture: Future<Output = io::Result<Self::File>>;
 
     /// open a file from given path.
@@ -23,7 +23,7 @@ pub trait Meta {
 }
 
 /// trait for chunk read from file and populate [BytesMut]
-pub trait ChunkRead: Meta + Sized {
+pub trait ChunkRead: Sized {
     /// future must own Self and BytesMut. usize is the count of bytes that is written to BytesMut.
     type Future: Future<Output = io::Result<Option<(Self, BytesMut, usize)>>>;
 

--- a/http/src/h2/proto/headers.rs
+++ b/http/src/h2/proto/headers.rs
@@ -316,7 +316,7 @@ pub fn parse_u64(src: &[u8]) -> Result<u64, ()> {
     let mut ret = 0;
 
     for d in src {
-        if !(b'0'..=b'9').contains(d) {
+        if d.is_ascii_digit() {
             return Err(());
         }
 


### PR DESCRIPTION
`ServeDir::serve` would attach `content-length` header automatically and no manual insertion after return needed anymore.