### PR TITLE
use unbounded channel for postgres client.

### DIFF
--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-# feature for single thread client that have lower overhead(no lock) at the cost of non thread safe.
+# feature for single thread client that have lower overhead(no lock) at the cost of no thread safety.
 single-thread = []
 
 [dependencies]
@@ -14,11 +14,11 @@ xitca-unsafe-collection = { version = "0.1", features = ["bytes", "channel"] }
 
 fallible-iterator = "0.2"
 futures-core = { version = "0.3", default-features = false }
-percent-encoding = "2.1.0"
-postgres-protocol = "0.6.4"
-postgres-types = "0.2.3"
-tokio = { version = "1.21", features = ["net", "sync"] }
-tracing = { version = "0.1.35", default-features = false }
+percent-encoding = "2"
+postgres-protocol = "0.6"
+postgres-types = "0.2"
+tokio = { version = "1.24", features = ["net", "sync"] }
+tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-tokio = { version = "1.21", features = ["rt"] }
+tokio = { version = "1.24", features = ["rt"] }

--- a/postgres/src/io/context.rs
+++ b/postgres/src/io/context.rs
@@ -24,7 +24,6 @@ impl<const LIMIT: usize> Context<LIMIT> {
         }
     }
 
-    #[cfg(not(feature = "single-thread"))]
     pub(super) fn req_is_full(&self) -> bool {
         self.req.is_full()
     }

--- a/postgres/src/prepare.rs
+++ b/postgres/src/prepare.rs
@@ -36,7 +36,7 @@ impl Client {
 
         let buf = self.prepare_buf(name.as_str(), query, types)?;
 
-        let mut res = self.send(buf).await?;
+        let mut res = self.send(buf)?;
 
         match res.recv().await? {
             backend::Message::ParseComplete => {}

--- a/postgres/src/query.rs
+++ b/postgres/src/query.rs
@@ -23,7 +23,7 @@ impl Client {
         I::IntoIter: ExactSizeIterator,
     {
         let buf = encode(self, stmt, params)?;
-        let mut res = self.send(buf).await?;
+        let mut res = self.send(buf)?;
 
         match res.recv().await? {
             backend::Message::BindComplete => {}

--- a/postgres/src/statement.rs
+++ b/postgres/src/statement.rs
@@ -39,7 +39,6 @@ impl<'a> StatementGuarded<'a> {
                 frontend::close(b'S', &statement.name, &mut buf).unwrap();
                 frontend::sync(&mut buf);
 
-                // TODO: fix this send. right now it's lazy and do nothing.
                 let _f = self.client.send(buf);
             }
         }


### PR DESCRIPTION
due to lack of AsyncDrop a bounded async channel would have trouble to cancel prepared statement with drop guard. use unbounded channel instead. 
client would not be able to handle backlog with naive unbounded channel and this issue would be addressed in the future.