### PR TITLE
rework body module and naming.

### DIFF
--- a/examples/file/src/main.rs
+++ b/examples/file/src/main.rs
@@ -8,7 +8,8 @@ use xitca_web::{
     http::{Method, Uri},
     middleware::compress::Compress,
     request::WebRequest,
-    response::{ResponseBody, StreamBody, WebResponse},
+    body::{ResponseBody, BoxStreamBody},
+    response::{ WebResponse},
     route::Route,
     App, HttpServer,
 };
@@ -41,7 +42,7 @@ fn main() -> std::io::Result<()> {
 async fn index(RequestRef(req): RequestRef<'_>, StateRef(dir): StateRef<'_, ServeDir>) -> WebResponse {
     match dir.serve(req).await {
         // map async file read stream to response body stream.
-        Ok(res) => res.map(|body| ResponseBody::stream(StreamBody::new(body))),
+        Ok(res) => res.map(|body| ResponseBody::stream(BoxStreamBody::new(body))),
         // map error to empty body response.
         Err(e) => e.into_response().map(|_| ResponseBody::bytes(Bytes::new())),
     }

--- a/examples/file/src/main.rs
+++ b/examples/file/src/main.rs
@@ -3,13 +3,13 @@
 
 use http_file::ServeDir;
 use xitca_web::{
+    body::ResponseBody,
     dev::{bytes::Bytes, service::Service},
     handler::{handler_service, request::RequestRef, state::StateRef},
     http::{Method, Uri},
     middleware::compress::Compress,
     request::WebRequest,
-    body::{ResponseBody, BoxStreamBody},
-    response::{ WebResponse},
+    response::WebResponse,
     route::Route,
     App, HttpServer,
 };
@@ -42,7 +42,7 @@ fn main() -> std::io::Result<()> {
 async fn index(RequestRef(req): RequestRef<'_>, StateRef(dir): StateRef<'_, ServeDir>) -> WebResponse {
     match dir.serve(req).await {
         // map async file read stream to response body stream.
-        Ok(res) => res.map(|body| ResponseBody::stream(BoxStreamBody::new(body))),
+        Ok(res) => res.map(ResponseBody::box_stream),
         // map error to empty body response.
         Err(e) => e.into_response().map(|_| ResponseBody::bytes(Bytes::new())),
     }

--- a/http/src/h1/proto/encode.rs
+++ b/http/src/h1/proto/encode.rs
@@ -248,7 +248,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        body::{Once, StreamBody},
+        body::{BoxStreamBody, Once},
         bytes::Bytes,
         date::DateTimeService,
         http::{HeaderValue, Response},
@@ -263,7 +263,7 @@ mod test {
                 let date = DateTimeService::new();
                 let mut ctx = Context::<_, 64>::new(date.get());
 
-                let mut res = Response::new(StreamBody::new(Once::new(Bytes::new())));
+                let mut res = Response::new(BoxStreamBody::new(Once::new(Bytes::new())));
 
                 res.headers_mut()
                     .insert(CONNECTION, HeaderValue::from_static("keep-alive"));

--- a/http/src/h1/proto/encode.rs
+++ b/http/src/h1/proto/encode.rs
@@ -248,7 +248,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        body::{BoxStreamBody, Once},
+        body::{BoxStream, Once},
         bytes::Bytes,
         date::DateTimeService,
         http::{HeaderValue, Response},
@@ -263,7 +263,7 @@ mod test {
                 let date = DateTimeService::new();
                 let mut ctx = Context::<_, 64>::new(date.get());
 
-                let mut res = Response::new(BoxStreamBody::new(Once::new(Bytes::new())));
+                let mut res = Response::new(BoxStream::new(Once::new(Bytes::new())));
 
                 res.headers_mut()
                     .insert(CONNECTION, HeaderValue::from_static("keep-alive"));

--- a/test/tests/h1.rs
+++ b/test/tests/h1.rs
@@ -7,7 +7,7 @@ use std::{
 
 use xitca_client::Client;
 use xitca_http::{
-    body::{BoxStreamBody, ResponseBody},
+    body::{BoxStream, ResponseBody},
     bytes::{Bytes, BytesMut},
     h1,
     http::{
@@ -228,7 +228,7 @@ async fn handle(req: Request<RequestExt<h1::RequestBody>>) -> Result<Response<Re
             let ty = req.headers().get(header::CONTENT_TYPE).unwrap().clone();
 
             let body = req.into_body();
-            let mut res = Response::new(ResponseBody::stream(BoxStreamBody::new(body)));
+            let mut res = Response::new(ResponseBody::stream(BoxStream::new(body)));
 
             res.headers_mut().insert(header::CONTENT_LENGTH, length);
             res.headers_mut().insert(header::CONTENT_TYPE, ty);

--- a/test/tests/h1.rs
+++ b/test/tests/h1.rs
@@ -7,7 +7,7 @@ use std::{
 
 use xitca_client::Client;
 use xitca_http::{
-    body::{ResponseBody, StreamBody},
+    body::{BoxStreamBody, ResponseBody},
     bytes::{Bytes, BytesMut},
     h1,
     http::{
@@ -228,7 +228,7 @@ async fn handle(req: Request<RequestExt<h1::RequestBody>>) -> Result<Response<Re
             let ty = req.headers().get(header::CONTENT_TYPE).unwrap().clone();
 
             let body = req.into_body();
-            let mut res = Response::new(ResponseBody::stream(StreamBody::new(body)));
+            let mut res = Response::new(ResponseBody::stream(BoxStreamBody::new(body)));
 
             res.headers_mut().insert(header::CONTENT_LENGTH, length);
             res.headers_mut().insert(header::CONTENT_TYPE, ty);

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -14,6 +14,7 @@ use xitca_http::util::service::{
 };
 
 use crate::{
+    body::ResponseBody,
     dev::{
         bytes::Bytes,
         service::{
@@ -24,7 +25,7 @@ use crate::{
     handler::Responder,
     http::{Request, RequestExt},
     request::WebRequest,
-    response::{ResponseBody, WebResponse},
+    response::WebResponse,
 };
 
 use self::object::WebObjectConstructor;

--- a/web/src/body.rs
+++ b/web/src/body.rs
@@ -2,13 +2,15 @@ use std::error;
 
 use futures_core::stream::Stream;
 
+pub use xitca_http::body::{BoxStreamBody, RequestBody, ResponseBody};
+
 /// A extended trait for [Stream] that specify additional type info of the [Stream::Item] type.
-pub trait WebStream: Stream<Item = Result<Self::Chunk, Self::Error>> {
+pub trait BodyStream: Stream<Item = Result<Self::Chunk, Self::Error>> {
     type Chunk: AsRef<[u8]> + 'static;
     type Error: error::Error + 'static;
 }
 
-impl<S, T, E> WebStream for S
+impl<S, T, E> BodyStream for S
 where
     S: Stream<Item = Result<T, E>>,
     T: AsRef<[u8]> + 'static,

--- a/web/src/body.rs
+++ b/web/src/body.rs
@@ -2,7 +2,7 @@ use std::error;
 
 use futures_core::stream::Stream;
 
-pub use xitca_http::body::{BoxStreamBody, RequestBody, ResponseBody};
+pub use xitca_http::body::{BoxStream, RequestBody, ResponseBody};
 
 /// A extended trait for [Stream] that specify additional type info of the [Stream::Item] type.
 pub trait BodyStream: Stream<Item = Result<Self::Chunk, Self::Error>> {

--- a/web/src/handler/impls.rs
+++ b/web/src/handler/impls.rs
@@ -3,6 +3,7 @@ use core::{convert::Infallible, future::Future};
 use std::{error, io};
 
 use crate::{
+    body::BodyStream,
     dev::bytes::Bytes,
     error::{MatchError, MethodNotAllowed},
     http::{
@@ -12,14 +13,13 @@ use crate::{
     },
     request::WebRequest,
     response::WebResponse,
-    stream::WebStream,
 };
 
 use super::{error::ExtractError, FromRequest, Responder};
 
 impl<'a, 'r, C, B, T, E> FromRequest<'a, WebRequest<'r, C, B>> for Result<T, E>
 where
-    B: WebStream,
+    B: BodyStream,
     T: for<'a2, 'r2> FromRequest<'a2, WebRequest<'r2, C, B>, Error = E>,
 {
     type Type<'b> = Result<T, E>;
@@ -34,7 +34,7 @@ where
 
 impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for Option<T>
 where
-    B: WebStream,
+    B: BodyStream,
     T: for<'a2, 'r2> FromRequest<'a2, WebRequest<'r2, C, B>>,
 {
     type Type<'b> = Option<T>;
@@ -50,7 +50,7 @@ where
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for &'a WebRequest<'a, C, B>
 where
     C: 'static,
-    B: WebStream + 'static,
+    B: BodyStream + 'static,
 {
     type Type<'b> = &'b WebRequest<'b, C, B>;
     type Error = ExtractError<B::Error>;
@@ -64,7 +64,7 @@ where
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for ()
 where
-    B: WebStream,
+    B: BodyStream,
 {
     type Type<'b> = ();
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/body.rs
+++ b/web/src/handler/types/body.rs
@@ -1,16 +1,16 @@
 use std::future::Future;
 
 use crate::{
+    body::BodyStream,
     handler::{error::ExtractError, FromRequest},
     request::WebRequest,
-    stream::WebStream,
 };
 
 pub struct Body<B>(pub B);
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for Body<B>
 where
-    B: WebStream + Default,
+    B: BodyStream + Default,
 {
     type Type<'b> = Body<B>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/extension.rs
+++ b/web/src/handler/types/extension.rs
@@ -1,10 +1,10 @@
 use std::{fmt, future::Future, ops::Deref};
 
 use crate::{
+    body::BodyStream,
     handler::{error::ExtractError, FromRequest},
     http::Extensions,
     request::WebRequest,
-    stream::WebStream,
 };
 
 /// Extract immutable reference of element stored inside [Extensions]
@@ -27,7 +27,7 @@ impl<T> Deref for ExtensionRef<'_, T> {
 impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for ExtensionRef<'a, T>
 where
     T: Send + Sync + 'static,
-    B: WebStream,
+    B: BodyStream,
 {
     type Type<'b> = ExtensionRef<'b, T>;
     type Error = ExtractError<B::Error>;
@@ -59,7 +59,7 @@ impl Deref for ExtensionsRef<'_> {
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for ExtensionsRef<'a>
 where
-    B: WebStream,
+    B: BodyStream,
 {
     type Type<'b> = ExtensionsRef<'b>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/header.rs
+++ b/web/src/handler/types/header.rs
@@ -1,10 +1,10 @@
 use std::{fmt, future::Future, ops::Deref};
 
 use crate::{
+    body::BodyStream,
     handler::{error::ExtractError, FromRequest},
     http::header::{self, HeaderValue},
     request::WebRequest,
-    stream::WebStream,
 };
 
 macro_rules! const_header_name {
@@ -59,7 +59,7 @@ impl<const HEADER_NAME: usize> Deref for HeaderRef<'_, HEADER_NAME> {
 
 impl<'a, 'r, C, B, const HEADER_NAME: usize> FromRequest<'a, WebRequest<'r, C, B>> for HeaderRef<'a, HEADER_NAME>
 where
-    B: WebStream,
+    B: BodyStream,
 {
     type Type<'b> = HeaderRef<'b, HEADER_NAME>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/json.rs
+++ b/web/src/handler/types/json.rs
@@ -8,6 +8,7 @@ use core::{
 use serde::{de::DeserializeOwned, ser::Serialize};
 
 use crate::{
+    body::BodyStream,
     dev::bytes::{BufMutWriter, BytesMut},
     handler::{
         error::{ExtractError, _ParseError},
@@ -16,7 +17,6 @@ use crate::{
     http::{const_header_value::JSON, header::CONTENT_TYPE},
     request::WebRequest,
     response::WebResponse,
-    stream::WebStream,
 };
 
 use super::{
@@ -60,7 +60,7 @@ impl<T, const LIMIT: usize> DerefMut for Json<T, LIMIT> {
 
 impl<'a, 'r, C, B, T, const LIMIT: usize> FromRequest<'a, WebRequest<'r, C, B>> for Json<T, LIMIT>
 where
-    B: WebStream + Default,
+    B: BodyStream + Default,
     T: DeserializeOwned,
 {
     type Type<'b> = Json<T, LIMIT>;

--- a/web/src/handler/types/multipart.rs
+++ b/web/src/handler/types/multipart.rs
@@ -1,16 +1,16 @@
 use core::future::Future;
 
 use crate::{
+    body::BodyStream,
     handler::{ExtractError, FromRequest},
     request::{RequestBody, WebRequest},
-    stream::WebStream,
 };
 
 pub type Multipart<'a, B = RequestBody> = http_multipart::Multipart<'a, B>;
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for Multipart<'a, B>
 where
-    B: WebStream + Default,
+    B: BodyStream + Default,
 {
     type Type<'b> = Multipart<'b, B>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/params.rs
+++ b/web/src/handler/types/params.rs
@@ -6,12 +6,12 @@ use serde::{forward_to_deserialize_any, Deserialize};
 use xitca_http::util::service::router;
 
 use crate::{
+    body::BodyStream,
     handler::{
         error::{ExtractError, _ParseError},
         FromRequest,
     },
     request::WebRequest,
-    stream::WebStream,
 };
 
 #[derive(Debug)]
@@ -19,7 +19,7 @@ pub struct Params<T>(pub T);
 
 impl<'a, 'r, T, C, B> FromRequest<'a, WebRequest<'r, C, B>> for Params<T>
 where
-    B: WebStream,
+    B: BodyStream,
     T: for<'de> Deserialize<'de>,
 {
     type Type<'b> = Params<T>;
@@ -50,7 +50,7 @@ impl Deref for ParamsRef<'_> {
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for ParamsRef<'a>
 where
-    B: WebStream,
+    B: BodyStream,
 {
     type Type<'b> = ParamsRef<'b>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/path.rs
+++ b/web/src/handler/types/path.rs
@@ -1,9 +1,9 @@
 use std::{future::Future, ops::Deref};
 
 use crate::{
+    body::BodyStream,
     handler::{error::ExtractError, FromRequest},
     request::WebRequest,
-    stream::WebStream,
 };
 
 #[derive(Debug)]
@@ -19,7 +19,7 @@ impl Deref for PathRef<'_> {
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for PathRef<'a>
 where
-    B: WebStream,
+    B: BodyStream,
 {
     type Type<'b> = PathRef<'b>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/query.rs
+++ b/web/src/handler/types/query.rs
@@ -3,12 +3,12 @@ use std::{fmt, future::Future};
 use serde::de::DeserializeOwned;
 
 use crate::{
+    body::BodyStream,
     handler::{
         error::{ExtractError, _ParseError},
         FromRequest,
     },
     request::WebRequest,
-    stream::WebStream,
 };
 
 pub struct Query<T>(pub T);
@@ -25,7 +25,7 @@ where
 impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for Query<T>
 where
     T: DeserializeOwned,
-    B: WebStream,
+    B: BodyStream,
 {
     type Type<'b> = Query<T>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/request.rs
+++ b/web/src/handler/types/request.rs
@@ -1,10 +1,10 @@
 use core::{future::Future, ops::Deref};
 
 use crate::{
+    body::BodyStream,
     handler::{error::ExtractError, FromRequest},
     http::{Request, RequestExt},
     request::WebRequest,
-    stream::WebStream,
 };
 
 #[derive(Debug)]
@@ -20,7 +20,7 @@ impl Deref for RequestRef<'_> {
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for RequestRef<'a>
 where
-    B: WebStream,
+    B: BodyStream,
 {
     type Type<'b> = RequestRef<'b>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/state.rs
+++ b/web/src/handler/types/state.rs
@@ -1,9 +1,9 @@
 use std::{borrow::Borrow, fmt, future::Future, ops::Deref};
 
 use crate::{
+    body::BodyStream,
     handler::{error::ExtractError, FromRequest},
     request::WebRequest,
-    stream::WebStream,
 };
 
 /// App state extractor.
@@ -33,7 +33,7 @@ impl<S> Deref for StateRef<'_, S> {
 impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for StateRef<'a, T>
 where
     C: Borrow<T>,
-    B: WebStream,
+    B: BodyStream,
     T: 'static,
 {
     type Type<'b> = StateRef<'b, T>;

--- a/web/src/handler/types/string.rs
+++ b/web/src/handler/types/string.rs
@@ -1,17 +1,17 @@
 use std::future::Future;
 
 use crate::{
+    body::BodyStream,
     handler::{
         error::{ExtractError, _ParseError},
         FromRequest,
     },
     request::WebRequest,
-    stream::WebStream,
 };
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for String
 where
-    B: WebStream + Default,
+    B: BodyStream + Default,
 {
     type Type<'b> = String;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/uri.rs
+++ b/web/src/handler/types/uri.rs
@@ -1,10 +1,10 @@
 use std::{future::Future, ops::Deref};
 
 use crate::{
+    body::BodyStream,
     handler::{error::ExtractError, FromRequest},
     http::Uri,
     request::WebRequest,
-    stream::WebStream,
 };
 
 #[derive(Debug)]
@@ -20,7 +20,7 @@ impl Deref for UriRef<'_> {
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for UriRef<'a>
 where
-    B: WebStream,
+    B: BodyStream,
 {
     type Type<'b> = UriRef<'b>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/vec.rs
+++ b/web/src/handler/types/vec.rs
@@ -4,15 +4,15 @@ use core::{
 };
 
 use crate::{
+    body::BodyStream,
     handler::{error::ExtractError, FromRequest, Responder},
     request::WebRequest,
     response::WebResponse,
-    stream::WebStream,
 };
 
 impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for Vec<u8>
 where
-    B: WebStream + Default,
+    B: BodyStream + Default,
 {
     type Type<'b> = Vec<u8>;
     type Error = ExtractError<B::Error>;

--- a/web/src/handler/types/websocket.rs
+++ b/web/src/handler/types/websocket.rs
@@ -15,12 +15,12 @@ use tokio::time::{sleep, Instant};
 use xitca_unsafe_collection::futures::{Select, SelectOutput};
 
 use crate::{
-    body::BodyStream,
+    body::{BodyStream, BoxStreamBody, RequestBody},
     dev::bytes::Bytes,
     handler::{error::ExtractError, FromRequest, Responder},
     http::header::{CONNECTION, SEC_WEBSOCKET_VERSION, UPGRADE},
-    request::{RequestBody, WebRequest},
-    response::{StreamBody, WebResponse},
+    request::WebRequest,
+    response::WebResponse,
 };
 
 type BoxFuture<'a> = Pin<Box<dyn Future<Output = ()> + 'a>>;
@@ -164,7 +164,7 @@ where
             let _ = spawn_task(ping_interval, max_unanswered_ping, decode, tx, on_msg, on_err, on_close).await;
         });
 
-        let res = res.map(|body| StreamBody::new(body).into());
+        let res = res.map(|body| BoxStreamBody::new(body).into());
 
         async { res }
     }

--- a/web/src/handler/types/websocket.rs
+++ b/web/src/handler/types/websocket.rs
@@ -15,7 +15,7 @@ use tokio::time::{sleep, Instant};
 use xitca_unsafe_collection::futures::{Select, SelectOutput};
 
 use crate::{
-    body::{BodyStream, BoxStreamBody, RequestBody},
+    body::{BodyStream, RequestBody, ResponseBody},
     dev::bytes::Bytes,
     handler::{error::ExtractError, FromRequest, Responder},
     http::header::{CONNECTION, SEC_WEBSOCKET_VERSION, UPGRADE},
@@ -164,7 +164,7 @@ where
             let _ = spawn_task(ping_interval, max_unanswered_ping, decode, tx, on_msg, on_err, on_close).await;
         });
 
-        let res = res.map(|body| BoxStreamBody::new(body).into());
+        let res = res.map(ResponseBody::box_stream);
 
         async { res }
     }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -5,13 +5,13 @@ mod app;
 #[cfg(feature = "__server")]
 mod server;
 
+pub mod body;
 pub mod error;
 pub mod handler;
 pub mod middleware;
 pub mod request;
 pub mod response;
 pub mod service;
-pub mod stream;
 pub mod test;
 
 #[cfg(feature = "codegen")]
@@ -57,8 +57,8 @@ pub mod dev {
 }
 
 pub use app::App;
+pub use body::BodyStream;
 #[cfg(feature = "__server")]
 pub use server::HttpServer;
-pub use stream::WebStream;
 
 pub use xitca_http::http;

--- a/web/src/middleware/compress.rs
+++ b/web/src/middleware/compress.rs
@@ -3,10 +3,10 @@ use core::{convert::Infallible, future::Future};
 use http_encoding::{encoder, Coder, ContentEncoding};
 
 use crate::{
+    body::BodyStream,
     dev::service::{ready::ReadyService, Service},
     request::WebRequest,
     response::WebResponse,
-    stream::WebStream,
 };
 
 /// A compress middleware look into [WebRequest]'s `Accept-Encoding` header and
@@ -37,7 +37,7 @@ where
     C: 'r,
     ReqB: 'r,
     S: for<'rs> Service<WebRequest<'rs, C, ReqB>, Response = WebResponse<ResB>, Error = Err>,
-    ResB: WebStream,
+    ResB: BodyStream,
 {
     type Response = WebResponse<Coder<ResB>>;
     type Error = Err;

--- a/web/src/middleware/decompress.rs
+++ b/web/src/middleware/decompress.rs
@@ -3,12 +3,12 @@ use core::{cell::RefCell, convert::Infallible, future::Future};
 use http_encoding::{error::EncodingError, Coder};
 
 use crate::{
+    body::BodyStream,
     dev::service::{pipeline::PipelineE, ready::ReadyService, Service},
     handler::Responder,
     http::{const_header_value::TEXT_UTF8, header::CONTENT_TYPE, Request, StatusCode},
     request::WebRequest,
     response::WebResponse,
-    stream::WebStream,
 };
 
 /// A decompress middleware look into [WebRequest]'s `Content-Encoding` header and
@@ -39,7 +39,7 @@ pub type DecompressServiceError<E> = PipelineE<EncodingError, E>;
 impl<'r, S, C, B, Res, Err> Service<WebRequest<'r, C, B>> for DecompressService<S>
 where
     C: 'r,
-    B: WebStream + Default + 'r,
+    B: BodyStream + Default + 'r,
     S: for<'rs> Service<WebRequest<'rs, C, Coder<B>>, Response = Res, Error = Err>,
 {
     type Response = Res;

--- a/web/src/middleware/decompress.rs
+++ b/web/src/middleware/decompress.rs
@@ -101,9 +101,10 @@ mod test {
     use crate::{dev::bytes::Bytes, http::header::CONTENT_ENCODING};
 
     use crate::{
+        body::ResponseBody,
         handler::handler_service,
         http::{Request, RequestExt},
-        response::{ResponseBody, WebResponse},
+        response::WebResponse,
         test::collect_body,
         App,
     };

--- a/web/src/middleware/eraser.rs
+++ b/web/src/middleware/eraser.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, error, future::Future, marker::PhantomData};
 use xitca_http::ResponseBody;
 
 use crate::{
-    body::{BodyStream, BoxStreamBody},
+    body::BodyStream,
     dev::{
         bytes::Bytes,
         service::{ready::ReadyService, Service},
@@ -102,7 +102,7 @@ where
     {
         async {
             let res = self.service.call(req).await?;
-            Ok(res.map(|b| ResponseBody::stream(BoxStreamBody::new(b))))
+            Ok(res.map(ResponseBody::box_stream))
         }
     }
 }

--- a/web/src/middleware/limit.rs
+++ b/web/src/middleware/limit.rs
@@ -192,11 +192,11 @@ mod test {
     use xitca_unsafe_collection::futures::NowOrPanic;
 
     use crate::{
+        body::BoxStream,
         dev::bytes::Bytes,
         error::BodyError,
         handler::{body::Body, handler_service},
         http::{Request, RequestExt},
-        response::StreamBody,
         test::collect_body,
         App,
     };
@@ -222,7 +222,7 @@ mod test {
         let item = || async { Ok::<_, BodyError>(Bytes::from_static(chunk)) };
 
         let body = stream::once(item()).chain(stream::once(item()));
-        let ext = RequestExt::default().map_body(|_: ()| StreamBody::new(body));
+        let ext = RequestExt::default().map_body(|_: ()| BoxStream::new(body));
         let req = Request::new(ext);
 
         let body = App::new()

--- a/web/src/request.rs
+++ b/web/src/request.rs
@@ -5,11 +5,9 @@ use core::{
     mem,
 };
 
-use xitca_http::body::ResponseBody;
-
 use crate::http::{BorrowReq, BorrowReqMut, IntoResponse, Request, RequestExt};
 
-use super::response::WebResponse;
+use super::{body::ResponseBody, response::WebResponse};
 
 pub struct WebRequest<'a, C = (), B = RequestBody> {
     pub(crate) req: &'a mut Request<RequestExt<()>>,

--- a/web/src/response.rs
+++ b/web/src/response.rs
@@ -1,8 +1,7 @@
-pub use xitca_http::{
-    body::{ResponseBody, StreamBody},
-    http::response::Builder as WebResponseBuilder,
-};
+pub use xitca_http::http::response::Builder as WebResponseBuilder;
 
 use xitca_http::response::Response;
+
+use super::body::ResponseBody;
 
 pub type WebResponse<B = ResponseBody> = Response<B>;


### PR DESCRIPTION
`xitca_web::stream` module has been renamed to `xitca_web::body`.
rename `xitca_web::WebStream` trait to `BodyStream`.
move `xitca_web::request::RequestBody` and `xitca_web::response::ResponseBody` to `xitca_web::body` module.
rename `xitca_http::body::StreamBody` to `BoxStream`.