### PR TITLE
experiment new behavior of consistent request timeout handling.

### DIFF
--- a/client/src/h1/proto/dispatcher.rs
+++ b/client/src/h1/proto/dispatcher.rs
@@ -4,7 +4,7 @@ use std::io;
 
 use futures_core::Stream;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use xitca_http::h1::proto::{codec::TransferCoding, context::ConnectionType};
+use xitca_http::h1::proto::codec::TransferCoding;
 
 use crate::{
     body::BodyError,
@@ -70,7 +70,7 @@ where
     // continue to read response no matter the outcome.
     if send_inner(stream, encoder, body, &mut buf).await.is_err() {
         // an error indicate connection should be closed.
-        ctx.set_ctype(ConnectionType::Close);
+        ctx.set_close();
         // clear the buffer as there could be unfinished request data inside.
         buf.clear();
     }

--- a/http/src/h1/dispatcher.rs
+++ b/http/src/h1/dispatcher.rs
@@ -118,7 +118,7 @@ where
             io: BufferedIo::new(io, write_buf),
             timer,
             ka_dur: config.keep_alive_timeout,
-            req_dur: config.first_request_timeout,
+            req_dur: config.request_head_timeout,
             ctx: Context::with_addr(addr, date),
             service,
             _phantom: PhantomData,

--- a/http/src/h1/proto/context.rs
+++ b/http/src/h1/proto/context.rs
@@ -44,12 +44,8 @@ impl ContextState {
 /// Represents various types of connection
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ConnectionType {
-    /// A connection that has no request yet.
-    Init,
-    /// Close connection after response with flush and shutdown IO.
+    Open,
     Close,
-    /// Keep connection alive after response
-    KeepAlive,
 }
 
 impl<'a, D, const HEADER_LIMIT: usize> Context<'a, D, HEADER_LIMIT> {
@@ -65,7 +61,7 @@ impl<'a, D, const HEADER_LIMIT: usize> Context<'a, D, HEADER_LIMIT> {
         Self {
             addr,
             state: ContextState::new(),
-            ctype: ConnectionType::Init,
+            ctype: ConnectionType::Open,
             header: None,
             exts: Extensions::new(),
             date,
@@ -109,7 +105,6 @@ impl<'a, D, const HEADER_LIMIT: usize> Context<'a, D, HEADER_LIMIT> {
     /// Reset Context's state to partial default state.
     #[inline]
     pub fn reset(&mut self) {
-        self.ctype = ConnectionType::KeepAlive;
         self.state = ContextState::new();
     }
 
@@ -155,7 +150,7 @@ impl<'a, D, const HEADER_LIMIT: usize> Context<'a, D, HEADER_LIMIT> {
         self.state.contains(ContextState::HEAD)
     }
 
-    /// Return true if connection type is [ConnectionType::Close] or [ConnectionType::CloseForce].
+    /// Return true if connection type is [ConnectionType::Close].
     #[inline]
     pub fn is_connection_closed(&self) -> bool {
         matches!(self.ctype, ConnectionType::Close)

--- a/http/src/h1/proto/context.rs
+++ b/http/src/h1/proto/context.rs
@@ -8,7 +8,6 @@ use crate::http::{header::HeaderMap, Extensions};
 pub struct Context<'a, D, const HEADER_LIMIT: usize> {
     addr: SocketAddr,
     state: ContextState,
-    ctype: ConnectionType,
     // header map reused by next request.
     header: Option<HeaderMap>,
     // http extensions reused by next request.
@@ -27,6 +26,8 @@ impl ContextState {
     const CONNECT: u8 = 0b_0010;
     // Enable when current request is HEAD method.
     const HEAD: u8 = 0b_0100;
+    // Enable when current connection is supposed to be closed after current response is sent.
+    const CLOSE: u8 = 0b_1000;
 
     const fn new() -> Self {
         Self(0)
@@ -36,16 +37,13 @@ impl ContextState {
         self.0 |= other;
     }
 
+    fn remove(&mut self, other: u8) {
+        self.0 &= !other;
+    }
+
     const fn contains(&self, other: u8) -> bool {
         (self.0 & other) == other
     }
-}
-
-/// Represents various types of connection
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum ConnectionType {
-    Open,
-    Close,
 }
 
 impl<'a, D, const HEADER_LIMIT: usize> Context<'a, D, HEADER_LIMIT> {
@@ -61,7 +59,6 @@ impl<'a, D, const HEADER_LIMIT: usize> Context<'a, D, HEADER_LIMIT> {
         Self {
             addr,
             state: ContextState::new(),
-            ctype: ConnectionType::Open,
             header: None,
             exts: Extensions::new(),
             date,
@@ -126,40 +123,40 @@ impl<'a, D, const HEADER_LIMIT: usize> Context<'a, D, HEADER_LIMIT> {
         self.state.insert(ContextState::HEAD)
     }
 
-    /// Set connection type.
+    /// Set Context's state to Close.
     #[inline]
-    pub fn set_ctype(&mut self, ctype: ConnectionType) {
-        self.ctype = ctype;
+    pub fn set_close(&mut self) {
+        self.state.insert(ContextState::CLOSE)
+    }
+
+    /// Remove Context's Close state.
+    #[inline]
+    pub fn remove_close(&mut self) {
+        self.state.remove(ContextState::CLOSE)
     }
 
     /// Get expect header state.
     #[inline]
-    pub fn is_expect_header(&self) -> bool {
+    pub const fn is_expect_header(&self) -> bool {
         self.state.contains(ContextState::EXPECT)
     }
 
     /// Get CONNECT method state.
     #[inline]
-    pub fn is_connect_method(&self) -> bool {
+    pub const fn is_connect_method(&self) -> bool {
         self.state.contains(ContextState::CONNECT)
     }
 
     /// Get HEAD method state.
     #[inline]
-    pub fn is_head_method(&self) -> bool {
+    pub const fn is_head_method(&self) -> bool {
         self.state.contains(ContextState::HEAD)
     }
 
     /// Return true if connection type is [ConnectionType::Close].
     #[inline]
-    pub fn is_connection_closed(&self) -> bool {
-        matches!(self.ctype, ConnectionType::Close)
-    }
-
-    /// Get connection type.
-    #[inline]
-    pub fn ctype(&self) -> ConnectionType {
-        self.ctype
+    pub const fn is_connection_closed(&self) -> bool {
+        self.state.contains(ContextState::CLOSE)
     }
 
     /// Get remote socket address context associated with.

--- a/http/src/h1/proto/decode.rs
+++ b/http/src/h1/proto/decode.rs
@@ -166,7 +166,7 @@ impl<D, const MAX_HEADERS: usize> Context<'_, D, MAX_HEADERS> {
         for val in val.to_str().map_err(|_| ProtoError::HeaderValue)?.split(',') {
             let val = val.trim();
             if val.eq_ignore_ascii_case("keep-alive") {
-                self.set_ctype(ConnectionType::KeepAlive)
+                self.set_ctype(ConnectionType::Open)
             } else if val.eq_ignore_ascii_case("close") {
                 self.set_ctype(ConnectionType::Close);
             }

--- a/http/src/h1/proto/decode.rs
+++ b/http/src/h1/proto/decode.rs
@@ -10,12 +10,7 @@ use crate::{
     util::buffered::PagedBytesMut,
 };
 
-use super::{
-    codec::TransferCoding,
-    context::{ConnectionType, Context},
-    error::ProtoError,
-    header::HeaderIndex,
-};
+use super::{codec::TransferCoding, context::Context, error::ProtoError, header::HeaderIndex};
 
 type Decoded = (Request<RequestExt<()>>, TransferCoding);
 
@@ -42,7 +37,7 @@ impl<D, const MAX_HEADERS: usize> Context<'_, D, MAX_HEADERS> {
                     // Default ctype is KeepAlive so set_ctype is skipped here.
                     Version::HTTP_11
                 } else {
-                    self.set_ctype(ConnectionType::Close);
+                    self.set_close();
                     Version::HTTP_10
                 };
 
@@ -166,9 +161,9 @@ impl<D, const MAX_HEADERS: usize> Context<'_, D, MAX_HEADERS> {
         for val in val.to_str().map_err(|_| ProtoError::HeaderValue)?.split(',') {
             let val = val.trim();
             if val.eq_ignore_ascii_case("keep-alive") {
-                self.set_ctype(ConnectionType::Open)
+                self.remove_close()
             } else if val.eq_ignore_ascii_case("close") {
-                self.set_ctype(ConnectionType::Close);
+                self.set_close()
             }
         }
         Ok(())

--- a/http/src/h1/service.rs
+++ b/http/src/h1/service.rs
@@ -49,9 +49,6 @@ where
                 .await
                 .map_err(|_| HttpServiceError::Timeout(TimeoutError::TlsAccept))??;
 
-            // update timer to first request timeout.
-            self.update_first_request_deadline(timer.as_mut());
-
             dispatcher::run(&mut io, addr, timer, self.config, &self.service, self.date.get())
                 .await
                 .map_err(Into::into)

--- a/http/src/service.rs
+++ b/http/src/service.rs
@@ -56,7 +56,7 @@ impl<St, S, ReqB, A, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, con
 
     #[cfg(feature = "http2")]
     pub(crate) fn update_first_request_deadline(&self, timer: core::pin::Pin<&mut KeepAlive>) {
-        let request_dur = self.config.first_request_timeout;
+        let request_dur = self.config.request_head_timeout;
         let deadline = self.date.get().now() + request_dur;
         timer.update(deadline);
     }
@@ -168,9 +168,6 @@ where
 
                     #[cfg(feature = "http1")]
                     {
-                        // update timer to first request timeout.
-                        self.update_first_request_deadline(timer.as_mut());
-
                         super::h1::dispatcher::run(
                             &mut _io,
                             crate::unspecified_socket_addr(),

--- a/http/src/util/hint.rs
+++ b/http/src/util/hint.rs
@@ -1,8 +1,0 @@
-#[inline]
-#[cold]
-fn cold() {}
-
-#[inline]
-pub(crate) fn unlikely() {
-    cold();
-}

--- a/http/src/util/mod.rs
+++ b/http/src/util/mod.rs
@@ -6,7 +6,5 @@ pub mod service;
 #[cfg(any(feature = "http1", feature = "http2"))]
 pub mod buffered;
 pub(crate) mod futures;
-#[cfg(feature = "http1")]
-pub(crate) mod hint;
 #[cfg(feature = "runtime")]
 pub(crate) mod timer;

--- a/http/src/util/timer.rs
+++ b/http/src/util/timer.rs
@@ -62,6 +62,7 @@ impl KeepAlive {
         }
     }
 
+    #[cfg(not(feature = "http3"))]
     #[inline]
     pub fn update(self: Pin<&mut Self>, deadline: Instant) {
         *self.project().deadline = deadline;

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -82,7 +82,7 @@ where
     test_server::<_, _, (TcpStream, SocketAddr)>(move || {
         let f = factory();
         let config = HttpServiceConfig::new()
-            .first_request_timeout(Duration::from_millis(500))
+            .request_head_timeout(Duration::from_millis(500))
             .tls_accept_timeout(Duration::from_millis(500))
             .keep_alive_timeout(Duration::from_millis(500));
         HttpServiceBuilder::h2(f).config(config)

--- a/web/src/server.rs
+++ b/web/src/server.rs
@@ -105,13 +105,13 @@ where
         self
     }
 
-    /// Change first request timeout for Http/1 connection.
+    /// Change request timeout for Http/1 connection.
     ///
-    /// Connection can not finish it's first request for this duration would be closed.
+    /// Connection can not finish it's request for this duration would be closed.
     ///
-    /// This timeout is also used on Http/2 connection handshake phrase.
-    pub fn first_request_timeout(mut self, dur: Duration) -> Self {
-        self.config = self.config.first_request_timeout(dur);
+    /// This timeout is also used in Http/2 connection handshake phrase.
+    pub fn request_head_timeout(mut self, dur: Duration) -> Self {
+        self.config = self.config.request_head_timeout(dur);
         self
     }
 


### PR DESCRIPTION
`xitca_http::confg::HttpServiceConfig::first_request_timeout` is renamed to `request_head_timeout`.
`xitca_web::HttpServer::first_request_timeout` is renamed accordingly.

Instead of handling only the first request timeout this api is able to handle all request timeout now.