### PR TITLE
move IntoObject trait to xitca_http::util::service::router.

### DIFF
--- a/http/src/util/service/context_priv.rs
+++ b/http/src/util/service/context_priv.rs
@@ -190,14 +190,14 @@ where
 pub type ContextObject<Req, C, Res, Err> =
     Box<dyn for<'c> xitca_service::object::ServiceObject<Context<'c, Req, C>, Response = Res, Error = Err>>;
 
-impl<C, I, Arg, Svc, BErr, Req, Res, Err> IntoObject<I, Arg> for Context<'_, Req, C>
+impl<C, I, Arg, Req, Res, Err> IntoObject<I, Arg> for Context<'_, Req, C>
 where
     C: 'static,
     Req: 'static,
-    I: Service<Arg, Response = Svc, Error = BErr> + 'static,
-    Svc: for<'c> Service<Context<'c, Req, C>, Response = Res, Error = Err> + 'static,
+    I: Service<Arg> + 'static,
+    I::Response: for<'c> Service<Context<'c, Req, C>, Response = Res, Error = Err> + 'static,
 {
-    type Object = BoxedServiceObject<Arg, ContextObject<Req, C, Res, Err>, BErr>;
+    type Object = BoxedServiceObject<Arg, ContextObject<Req, C, Res, Err>, I::Error>;
 
     fn into_object(inner: I) -> Self::Object {
         struct Builder<I, Req, C>(I, PhantomData<(Req, C)>);

--- a/http/src/util/service/context_priv.rs
+++ b/http/src/util/service/context_priv.rs
@@ -202,13 +202,13 @@ where
     fn into_object(inner: I) -> Self::Object {
         struct Builder<I, Req, C>(I, PhantomData<(Req, C)>);
 
-        impl<C, I, Arg, Svc, BErr, Req, Res, Err> Service<Arg> for Builder<I, Req, C>
+        impl<C, I, Arg, Req, Res, Err> Service<Arg> for Builder<I, Req, C>
         where
-            I: Service<Arg, Response = Svc, Error = BErr>,
-            Svc: for<'c> Service<Context<'c, Req, C>, Response = Res, Error = Err> + 'static,
+            I: Service<Arg>,
+            I::Response: for<'c> Service<Context<'c, Req, C>, Response = Res, Error = Err> + 'static,
         {
             type Response = ContextObject<Req, C, Res, Err>;
-            type Error = BErr;
+            type Error = I::Error;
             type Future<'f> = impl Future<Output = Result<Self::Response, Self::Error>> + 'f where Arg:'f, Self: 'f;
 
             fn call<'s>(&'s self, arg: Arg) -> Self::Future<'s>

--- a/http/src/util/service/mod.rs
+++ b/http/src/util/service/mod.rs
@@ -5,11 +5,11 @@ mod context_priv;
 mod router_priv;
 
 pub mod context {
-    pub use super::context_priv::{object, Context, ContextBuilder, ContextError};
+    pub use super::context_priv::{Context, ContextBuilder, ContextError};
 }
 
 pub mod router {
-    pub use super::router_priv::{MatchError, Params, PathGen, Router, RouterError};
+    pub use super::router_priv::{IntoObject, MatchError, Params, PathGen, Router, RouterError};
 }
 
 pub use router_priv::{Router, RouterError};

--- a/http/src/util/service/router_priv.rs
+++ b/http/src/util/service/router_priv.rs
@@ -5,23 +5,20 @@ use core::{future::Future, marker::PhantomData};
 use std::{borrow::Cow, collections::HashMap};
 
 use xitca_service::{
-    object::{DefaultObjectConstructor, IntoObject},
-    pipeline::PipelineE,
-    ready::ReadyService,
-    EnclosedFactory, EnclosedFnFactory, FnService, Service,
+    object::BoxedServiceObject, pipeline::PipelineE, ready::ReadyService, EnclosedFactory, EnclosedFnFactory,
+    FnService, Service,
 };
 
-use crate::http::{BorrowReq, BorrowReqMut, Uri};
+use crate::http::{BorrowReq, BorrowReqMut, Request, Uri};
 
 use super::route::Route;
 
-/// Simple router for matching on [Request](crate::http::Request)'s path and call according service.
+/// Simple router for matching path and call according service.
 ///
-/// An [ObjectConstructor] must be specified as a type parameter
+/// An [ServiceObject](xitca_service::object::ServiceObject) must be specified as a type parameter
 /// in order to determine how the router type-erases node services.
-pub struct Router<SF, ObjCons = DefaultObjectConstructor> {
-    routes: HashMap<Cow<'static, str>, SF>,
-    _obj: PhantomData<ObjCons>,
+pub struct Router<Obj> {
+    routes: HashMap<Cow<'static, str>, Obj>,
 }
 
 /// Error type of Router service.
@@ -29,27 +26,19 @@ pub struct Router<SF, ObjCons = DefaultObjectConstructor> {
 /// `Second` variant contains error returned by the services passed to Router.
 pub type RouterError<E> = PipelineE<MatchError, E>;
 
-impl<SF, ObjCons> Default for Router<SF, ObjCons> {
+impl<Obj> Default for Router<Obj> {
     fn default() -> Self {
-        Router::with_custom_object()
+        Router::new()
     }
 }
 
-impl<SF> Router<SF> {
+impl<Obj> Router<Obj> {
     pub fn new() -> Self {
-        Router::with_custom_object()
-    }
-
-    /// Creates a new router with a custom [object constructor](ObjectConstructor).
-    pub fn with_custom_object<ObjCons>() -> Router<SF, ObjCons> {
-        Router {
-            routes: HashMap::new(),
-            _obj: PhantomData,
-        }
+        Router { routes: HashMap::new() }
     }
 }
 
-impl<SF, ObjCons> Router<SF, ObjCons> {
+impl<Obj> Router<Obj> {
     /// Insert a new service factory to given path.
     ///
     /// # Panic:
@@ -57,11 +46,12 @@ impl<SF, ObjCons> Router<SF, ObjCons> {
     /// When multiple services inserted with the same path.
     pub fn insert<F, Arg, Req>(mut self, path: &'static str, mut factory: F) -> Self
     where
-        F: PathGen,
-        ObjCons: IntoObject<F, Arg, Req, Object = SF>,
+        F: Service<Arg> + PathGen,
+        F::Response: Service<Req>,
+        Req: IntoObject<F, Arg, Object = Obj>,
     {
         let path = factory.gen(path);
-        assert!(self.routes.insert(path, ObjCons::into_object(factory)).is_none());
+        assert!(self.routes.insert(path, Req::into_object(factory)).is_none());
         self
     }
 }
@@ -75,7 +65,7 @@ pub trait PathGen {
 }
 
 // nest router needs special handling for path generation.
-impl<SF, ObjCons> PathGen for Router<SF, ObjCons> {
+impl<Obj> PathGen for Router<Obj> {
     fn gen(&mut self, prefix: &'static str) -> Cow<'static, str> {
         let mut path = String::from(prefix);
         if path.ends_with('/') {
@@ -120,13 +110,13 @@ where
     }
 }
 
-impl<SF, ObjCons, Arg> Service<Arg> for Router<SF, ObjCons>
+impl<Obj, Arg> Service<Arg> for Router<Obj>
 where
-    SF: Service<Arg>,
+    Obj: Service<Arg>,
     Arg: Clone,
 {
-    type Response = RouterService<SF::Response>;
-    type Error = SF::Error;
+    type Response = RouterService<Obj::Response>;
+    type Error = Obj::Error;
     type Future<'f> = impl Future<Output = Result<Self::Response, Self::Error>> + 'f where Self: 'f, Arg: 'f;
 
     fn call<'s>(&'s self, arg: Arg) -> Self::Future<'s>
@@ -182,6 +172,51 @@ impl<S> ReadyService for RouterService<S> {
     #[inline]
     fn ready(&self) -> Self::Future<'_> {
         async {}
+    }
+}
+
+/// An object constructor represents a one of possibly many ways to create a trait object from `I`.
+///
+/// A [Service] type, for example, may be type-erased into `Box<dyn Service<&'static str>>`,
+/// `Box<dyn for<'a> Service<&'a str>>`, `Box<dyn Service<&'static str> + Service<u8>>`, etc.
+/// Each would be a separate impl for [IntoObject].
+pub trait IntoObject<I, Arg> {
+    /// The type-erased form of `I`.
+    type Object;
+
+    /// Constructs `Self::Object` from `I`.
+    fn into_object(inner: I) -> Self::Object;
+}
+
+impl<T, Arg, Ext, BErr, Res, Err> IntoObject<T, Arg> for Request<Ext>
+where
+    Ext: 'static,
+    T: Service<Arg, Error = BErr> + 'static,
+    T::Response: Service<Request<Ext>, Response = Res, Error = Err> + 'static,
+{
+    type Object = BoxedServiceObject<Arg, BoxedServiceObject<Request<Ext>, Res, Err>, BErr>;
+
+    fn into_object(inner: T) -> Self::Object {
+        struct Builder<T, Req>(T, PhantomData<Req>);
+
+        impl<T, Req, Arg, BErr, Res, Err> Service<Arg> for Builder<T, Req>
+        where
+            T: Service<Arg, Error = BErr> + 'static,
+            T::Response: Service<Req, Response = Res, Error = Err> + 'static,
+        {
+            type Response = BoxedServiceObject<Req, Res, Err>;
+            type Error = BErr;
+            type Future<'f> = impl Future<Output = Result<Self::Response, Self::Error>> + 'f where Self: 'f, Arg: 'f;
+
+            fn call<'s>(&'s self, req: Arg) -> Self::Future<'s>
+            where
+                Arg: 's,
+            {
+                async { self.0.call(req).await.map(|s| Box::new(s) as _) }
+            }
+        }
+
+        Box::new(Builder(inner, PhantomData))
     }
 }
 

--- a/service/src/service/ext.rs
+++ b/service/src/service/ext.rs
@@ -3,9 +3,6 @@ use crate::{
     pipeline::{marker, PipelineT},
 };
 
-#[cfg(feature = "alloc")]
-use crate::object::{DefaultObjectConstructor, IntoObject};
-
 use super::Service;
 
 pub trait ServiceExt<Arg>: Service<Arg> {
@@ -55,20 +52,6 @@ pub trait ServiceExt<Arg>: Service<Arg> {
         Self: Sized,
     {
         PipelineT::new(self, factory)
-    }
-
-    #[cfg(feature = "alloc")]
-    /// Box self and cast it to a trait object.
-    ///
-    /// This would erase `Self::Response` type and it's GAT nature.
-    ///
-    /// See [crate::object::DefaultObjectConstructor] for detail.
-    fn into_object<Req>(self) -> <DefaultObjectConstructor as IntoObject<Self, Arg, Req>>::Object
-    where
-        Self: Sized,
-        DefaultObjectConstructor: IntoObject<Self, Arg, Req>,
-    {
-        DefaultObjectConstructor::into_object(self)
     }
 }
 
@@ -134,7 +117,6 @@ mod test {
     fn service_object() {
         let service = fn_service(index)
             .enclosed(DummyMiddleware)
-            .into_object()
             .call(())
             .now_or_panic()
             .unwrap();
@@ -192,7 +174,6 @@ mod test {
     fn enclosed_opt() {
         let service = fn_service(index)
             .enclosed(Some(DummyMiddleware))
-            .into_object()
             .call(())
             .now_or_panic()
             .unwrap();

--- a/web/src/app/object.rs
+++ b/web/src/app/object.rs
@@ -1,17 +1,16 @@
-use std::{boxed::Box, future::Future, marker::PhantomData};
+use core::{future::Future, marker::PhantomData};
 
+use xitca_http::util::service::router::IntoObject;
 use xitca_service::{
-    object::{BoxedServiceObject, IntoObject, ServiceObject},
+    object::{BoxedServiceObject, ServiceObject},
     Service,
 };
 
 use crate::request::WebRequest;
 
-pub struct WebObjectConstructor;
-
 pub type WebObject<C, B, Res, Err> = Box<dyn for<'r> ServiceObject<WebRequest<'r, C, B>, Response = Res, Error = Err>>;
 
-impl<C, B, I, Svc, BErr, Res, Err> IntoObject<I, (), WebRequest<'_, C, B>> for WebObjectConstructor
+impl<C, B, I, Svc, BErr, Res, Err> IntoObject<I, ()> for WebRequest<'_, C, B>
 where
     C: 'static,
     B: 'static,

--- a/web/src/app/object.rs
+++ b/web/src/app/object.rs
@@ -10,25 +10,25 @@ use crate::request::WebRequest;
 
 pub type WebObject<C, B, Res, Err> = Box<dyn for<'r> ServiceObject<WebRequest<'r, C, B>, Response = Res, Error = Err>>;
 
-impl<C, B, I, Svc, BErr, Res, Err> IntoObject<I, ()> for WebRequest<'_, C, B>
+impl<C, B, I, Res, Err> IntoObject<I, ()> for WebRequest<'_, C, B>
 where
     C: 'static,
     B: 'static,
-    I: Service<Response = Svc, Error = BErr> + 'static,
-    Svc: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
+    I: Service + 'static,
+    I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
 {
-    type Object = BoxedServiceObject<(), WebObject<C, B, Res, Err>, BErr>;
+    type Object = BoxedServiceObject<(), WebObject<C, B, Res, Err>, I::Error>;
 
     fn into_object(inner: I) -> Self::Object {
         struct Builder<I, C, B>(I, PhantomData<(C, B)>);
 
-        impl<C, I, Svc, BErr, B, Res, Err> Service for Builder<I, C, B>
+        impl<C, I, B, Res, Err> Service for Builder<I, C, B>
         where
-            I: Service<Response = Svc, Error = BErr> + 'static,
-            Svc: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
+            I: Service + 'static,
+            I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
         {
             type Response = WebObject<C, B, Res, Err>;
-            type Error = BErr;
+            type Error = I::Error;
             type Future<'f> = impl Future<Output = Result<Self::Response, Self::Error>> + 'f where Self: 'f;
 
             fn call<'s>(&'s self, arg: ()) -> Self::Future<'s>


### PR DESCRIPTION
The usage of `IntoObject` will be narrowed down to only usable for storing object safe `Service` type in `Router`.
In exchange specialized `ServiceObject` type can be infered from it's Request type removing the need for `Router::with_custom_object` API(and it's constructor type).