### PR TITLE
narrow util-service feature down to router.

### DIFF
--- a/examples/cloudflare-worker/Cargo.toml
+++ b/examples/cloudflare-worker/Cargo.toml
@@ -13,7 +13,7 @@ http-file = { version = "0.1", default-features = false }
 rust-embed = "8"
 serde_json = "1.0.89"
 worker = "0.0.18"
-xitca-http = { version = "0.1", default-features = false, features = ["util-service"] }
+xitca-http = { version = "0.1", default-features = false, features = ["router"] }
 xitca-service = "0.1"
 xitca-unsafe-collection = "0.1"
 

--- a/examples/grpc/Cargo.toml
+++ b/examples/grpc/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["fakeshadow <24548779@qq.com>"]
 edition = "2021"
 
 [dependencies]
-xitca-http = { version = "0.1", default-features = false, features = ["http2", "util-service"] }
+xitca-http = { version = "0.1", default-features = false, features = ["http2", "router"] }
 xitca-server= "0.1"
 xitca-service = "0.1"
 

--- a/examples/io-uring/Cargo.toml
+++ b/examples/io-uring/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["fakeshadow <24548779@qq.com>"]
 edition = "2021"
 
 [dependencies]
-xitca-http = { version = "0.1", features = ["io-uring", "util-service", "rustls-uring"] }
+xitca-http = { version = "0.1", features = ["io-uring", "router", "rustls-uring"] }
 xitca-server = { version = "0.1", features = ["io-uring"] }
 xitca-service = "0.1"
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -25,7 +25,7 @@ runtime = ["xitca-io/runtime", "tokio"]
 
 # unstable features that are subject to be changed at anytime.
 io-uring = ["xitca-io/runtime-uring", "tokio-uring"]
-util-service = ["xitca-router"]
+router = ["xitca-router"]
 
 [dependencies]
 xitca-io = "0.1"

--- a/http/src/http.rs
+++ b/http/src/http.rs
@@ -87,7 +87,7 @@ where
     }
 }
 
-#[cfg(feature = "util-service")]
+#[cfg(feature = "router")]
 use super::util::service::router::Params;
 
 pin_project! {
@@ -109,7 +109,7 @@ impl Extension {
     pub(crate) fn new(addr: SocketAddr) -> Self {
         Self(Box::new(_Extension {
             addr,
-            #[cfg(feature = "util-service")]
+            #[cfg(feature = "router")]
             params: Default::default(),
         }))
     }
@@ -118,7 +118,7 @@ impl Extension {
 #[derive(Debug)]
 struct _Extension {
     addr: SocketAddr,
-    #[cfg(feature = "util-service")]
+    #[cfg(feature = "router")]
     params: Params,
 }
 
@@ -156,7 +156,7 @@ impl<B> RequestExt<B> {
     }
 }
 
-#[cfg(feature = "util-service")]
+#[cfg(feature = "router")]
 impl<B> RequestExt<B> {
     #[inline]
     pub fn params(&self) -> &Params {
@@ -202,7 +202,7 @@ impl<B> Borrow<SocketAddr> for RequestExt<B> {
     }
 }
 
-#[cfg(feature = "util-service")]
+#[cfg(feature = "router")]
 impl<B> Borrow<Params> for RequestExt<B> {
     #[inline]
     fn borrow(&self) -> &Params {
@@ -210,7 +210,7 @@ impl<B> Borrow<Params> for RequestExt<B> {
     }
 }
 
-#[cfg(feature = "util-service")]
+#[cfg(feature = "router")]
 impl<B> BorrowMut<Params> for RequestExt<B> {
     #[inline]
     fn borrow_mut(&mut self) -> &mut Params {

--- a/http/src/util/mod.rs
+++ b/http/src/util/mod.rs
@@ -1,6 +1,5 @@
 pub mod middleware;
 
-#[cfg(feature = "util-service")]
 pub mod service;
 
 #[cfg(any(feature = "http1", feature = "http2"))]

--- a/http/src/util/service/handler.rs
+++ b/http/src/util/service/handler.rs
@@ -291,10 +291,7 @@ mod test {
     use xitca_service::{Service, ServiceExt};
     use xitca_unsafe_collection::futures::NowOrPanic;
 
-    use crate::{
-        http::{Request, RequestExt, Response, StatusCode},
-        util::service::{route::get, Router},
-    };
+    use crate::http::{Request, RequestExt, Response, StatusCode};
 
     use super::*;
 
@@ -380,8 +377,11 @@ mod test {
         assert_eq!(res.status(), StatusCode::MULTI_STATUS);
     }
 
+    #[cfg(feature = "router")]
     #[test]
     fn handler_in_router() {
+        use crate::util::service::{route::get, Router};
+
         let res = Router::new()
             .insert("/", get(handler_service(handler)))
             .call(())

--- a/http/src/util/service/mod.rs
+++ b/http/src/util/service/mod.rs
@@ -2,14 +2,18 @@ pub mod handler;
 pub mod route;
 
 mod context_priv;
-mod router_priv;
 
 pub mod context {
     pub use super::context_priv::{Context, ContextBuilder, ContextError};
 }
 
+#[cfg(feature = "router")]
+mod router_priv;
+
+#[cfg(feature = "router")]
 pub mod router {
     pub use super::router_priv::{IntoObject, MatchError, Params, PathGen, Router, RouterError};
 }
 
+#[cfg(feature = "router")]
 pub use router_priv::{Router, RouterError};

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -48,7 +48,7 @@ tower-http-compat = ["tower-service", "tower-layer", "http-body"]
 __server = ["xitca-http/runtime", "xitca-server"]
 
 [dependencies]
-xitca-http = { version = "0.1", features = ["util-service"], default-features = false }
+xitca-http = { version = "0.1", features = ["router"], default-features = false }
 xitca-service = { version = "0.1", features = ["alloc", "std"] }
 xitca-unsafe-collection = "0.1"
 


### PR DESCRIPTION
Of all the util services only router depend on extra dependency. This PR enable all util services by default and make router service an optional feature.