### PR TITLE
add marker type to IntoObject trait.

### DIFF
--- a/http/src/util/service/mod.rs
+++ b/http/src/util/service/mod.rs
@@ -6,7 +6,9 @@ mod router_priv;
 
 #[cfg(feature = "router")]
 pub mod router {
-    pub use super::router_priv::{IntoObject, MatchError, Params, PathGen, Router, RouterError};
+    pub use super::router_priv::{
+        IntoObject, MatchError, Params, PathGen, Router, RouterError, SyncMarker, UnSyncMarker,
+    };
 }
 
 #[cfg(feature = "router")]

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -10,7 +10,7 @@ use core::{
 use futures_core::stream::Stream;
 use xitca_http::util::{
     middleware::context::{Context, ContextBuilder},
-    service::router::{IntoObject, PathGen, Router},
+    service::router::{IntoObject, PathGen, Router, SyncMarker},
 };
 
 use crate::{
@@ -72,11 +72,11 @@ impl<CF, Obj> App<CF, Router<Obj>> {
     where
         CF: Fn() -> Fut,
         Fut: Future<Output = Result<C, E>>,
-        F: PathGen + Service,
+        F: PathGen + Service + Send + Sync,
         F::Response: for<'r> Service<WebRequest<'r, C, B>>,
-        for<'r> WebRequest<'r, C, B>: IntoObject<F, (), Object = Obj>,
+        for<'r> WebRequest<'r, C, B>: IntoObject<F, (), SyncMarker, Object = Obj>,
     {
-        self.router = self.router.insert(path, factory);
+        self.router = self.router.insert_sync(path, factory);
         self
     }
 }

--- a/web/src/app/object.rs
+++ b/web/src/app/object.rs
@@ -1,40 +1,37 @@
 use core::marker::PhantomData;
 
-use xitca_http::util::service::router::IntoObject;
-use xitca_service::{
-    object::{BoxedServiceObject, ServiceObject},
-    Service,
-};
+use xitca_http::util::service::router::{IntoObject, SyncMarker};
+use xitca_service::{object::ServiceObject, Service};
 
 use crate::request::WebRequest;
 
 pub type WebObject<C, B, Res, Err> = Box<dyn for<'r> ServiceObject<WebRequest<'r, C, B>, Response = Res, Error = Err>>;
 
-impl<C, B, I, Res, Err> IntoObject<I, ()> for WebRequest<'_, C, B>
+impl<C, B, I, Res, Err> IntoObject<I, (), SyncMarker> for WebRequest<'_, C, B>
 where
     C: 'static,
     B: 'static,
+    I: Service + Send + Sync + 'static,
+    I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
+{
+    type Object = Box<dyn ServiceObject<(), Response = WebObject<C, B, Res, Err>, Error = I::Error> + Send + Sync>;
+
+    fn into_object(inner: I) -> Self::Object {
+        Box::new(Builder(inner, PhantomData))
+    }
+}
+
+struct Builder<I, C, B>(I, PhantomData<fn(C, B)>);
+
+impl<C, I, B, Res, Err> Service for Builder<I, C, B>
+where
     I: Service + 'static,
     I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
 {
-    type Object = BoxedServiceObject<(), WebObject<C, B, Res, Err>, I::Error>;
+    type Response = WebObject<C, B, Res, Err>;
+    type Error = I::Error;
 
-    fn into_object(inner: I) -> Self::Object {
-        struct Builder<I, C, B>(I, PhantomData<(C, B)>);
-
-        impl<C, I, B, Res, Err> Service for Builder<I, C, B>
-        where
-            I: Service + 'static,
-            I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
-        {
-            type Response = WebObject<C, B, Res, Err>;
-            type Error = I::Error;
-
-            async fn call(&self, arg: ()) -> Result<Self::Response, Self::Error> {
-                self.0.call(arg).await.map(|s| Box::new(s) as _)
-            }
-        }
-
-        Box::new(Builder(inner, PhantomData))
+    async fn call(&self, arg: ()) -> Result<Self::Response, Self::Error> {
+        self.0.call(arg).await.map(|s| Box::new(s) as _)
     }
 }

--- a/web/src/middleware/decompress.rs
+++ b/web/src/middleware/decompress.rs
@@ -147,24 +147,27 @@ mod test {
         // a hack to generate a compressed client request from server response.
         let res = WebResponse::<ResponseBody>::new(ResponseBody::bytes(Bytes::from_static(Q)));
 
-        let encoding = {
+        #[allow(unreachable_code)]
+        let encoding = || {
             #[cfg(all(feature = "compress-br", not(any(feature = "compress-gz", feature = "compress-de"))))]
             {
-                ContentEncoding::Br
+                return ContentEncoding::Br;
             }
+
             #[cfg(all(feature = "compress-gz", not(any(feature = "compress-br", feature = "compress-de"))))]
             {
-                ContentEncoding::Gzip
+                return ContentEncoding::Gzip;
             }
+
             #[cfg(all(feature = "compress-de", not(any(feature = "compress-br", feature = "compress-gz"))))]
             {
-                ContentEncoding::Deflate
+                return ContentEncoding::Deflate;
             }
-            #[cfg(all(feature = "compress-de", feature = "compress-br", feature = "compress-gz"))]
-            {
-                ContentEncoding::Br
-            }
+
+            ContentEncoding::Br
         };
+
+        let encoding = encoding();
 
         let (mut parts, body) = encoder(res, encoding).into_parts();
 


### PR DESCRIPTION
This enables router to be a `Send` and `Sync` constructor type with the help of `Router::insert_sync` API.
the default Router construction is still `!Send` and `!Sync` in `xitca-http` and the default App construction is forced to be `Send` and `Sync` in `xitca-web`.