### PR TITLE
remove using of function closure in HttpServer.

### DIFF
--- a/examples/compression/src/main.rs
+++ b/examples/compression/src/main.rs
@@ -13,13 +13,13 @@ fn main() -> io::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter("xitca=trace,[xitca-logger]=trace")
         .init();
-    HttpServer::new(|| {
+    HttpServer::serve(
         App::new()
             .at("/", handler_service(root))
             .enclosed(Compress)
             .enclosed(Decompress)
-            .finish()
-    })
+            .finish(),
+    )
     .bind("127.0.0.1:8080")?
     .run()
     .wait()

--- a/examples/compression/src/main.rs
+++ b/examples/compression/src/main.rs
@@ -6,23 +6,21 @@ use tracing::info;
 use xitca_web::{
     handler::handler_service,
     middleware::{compress::Compress, decompress::Decompress},
-    App, HttpServer,
+    App,
 };
 
 fn main() -> io::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter("xitca=trace,[xitca-logger]=trace")
         .init();
-    HttpServer::serve(
-        App::new()
-            .at("/", handler_service(root))
-            .enclosed(Compress)
-            .enclosed(Decompress)
-            .finish(),
-    )
-    .bind("127.0.0.1:8080")?
-    .run()
-    .wait()
+    App::new()
+        .at("/", handler_service(root))
+        .enclosed(Compress)
+        .enclosed(Decompress)
+        .serve()
+        .bind("127.0.0.1:8080")?
+        .run()
+        .wait()
 }
 
 async fn root(string: String) -> &'static str {

--- a/examples/file/src/main.rs
+++ b/examples/file/src/main.rs
@@ -17,26 +17,22 @@ use xitca_web::{
 
 fn main() -> std::io::Result<()> {
     println!("open http://localhost:8080 in browser to visit the site");
-    // construct a serve dir service
-    let serve = ServeDir::new("static");
-    HttpServer::new(move || {
-        // use serve dir service as app state.
-        App::with_multi_thread_state(serve.clone())
-            // catch all request path.
-            .at(
-                "/*path",
-                // only accept get/post method.
-                Route::new([Method::GET, Method::HEAD]).route(handler_service(index)),
-            )
-            // compression middleware
-            .enclosed(Compress)
-            // simple function middleware that intercept empty path and replace it with index.html
-            .enclosed_fn(path)
-            .finish()
-    })
-    .bind("localhost:8080")?
-    .run()
-    .wait()
+
+    // use serve dir service as app state.
+    let app = App::with_state(ServeDir::new("static"))
+        // catch all request path.
+        .at(
+            "/*path",
+            // only accept get/post method.
+            Route::new([Method::GET, Method::HEAD]).route(handler_service(index)),
+        )
+        // compression middleware
+        .enclosed(Compress)
+        // simple function middleware that intercept empty path and replace it with index.html
+        .enclosed_fn(path)
+        .finish();
+
+    HttpServer::serve(app).bind("localhost:8080")?.run().wait()
 }
 
 // extract request and serve dir state and start serving file.

--- a/examples/file/src/main.rs
+++ b/examples/file/src/main.rs
@@ -12,14 +12,14 @@ use xitca_web::{
     request::WebRequest,
     response::WebResponse,
     route::Route,
-    App, HttpServer,
+    App,
 };
 
 fn main() -> std::io::Result<()> {
     println!("open http://localhost:8080 in browser to visit the site");
 
     // use serve dir service as app state.
-    let app = App::with_state(ServeDir::new("static"))
+    App::with_state(ServeDir::new("static"))
         // catch all request path.
         .at(
             "/*path",
@@ -30,9 +30,10 @@ fn main() -> std::io::Result<()> {
         .enclosed(Compress)
         // simple function middleware that intercept empty path and replace it with index.html
         .enclosed_fn(path)
-        .finish();
-
-    HttpServer::serve(app).bind("localhost:8080")?.run().wait()
+        .serve()
+        .bind("localhost:8080")?
+        .run()
+        .wait()
 }
 
 // extract request and serve dir state and start serving file.

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,11 +1,12 @@
 //! A Http server returns Hello World String as Response.
 
-use xitca_web::{handler::handler_service, route::get, App, HttpServer};
+use xitca_web::{handler::handler_service, route::get, App};
 
 fn main() -> std::io::Result<()> {
-    let app = App::new()
+    App::new()
         .at("/", get(handler_service(|| async { "Hello,World!" })))
-        .finish();
-
-    HttpServer::serve(app).bind("127.0.0.1:8080")?.run().wait()
+        .serve()
+        .bind("127.0.0.1:8080")?
+        .run()
+        .wait()
 }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -3,12 +3,9 @@
 use xitca_web::{handler::handler_service, route::get, App, HttpServer};
 
 fn main() -> std::io::Result<()> {
-    HttpServer::new(|| {
-        App::new()
-            .at("/", get(handler_service(|| async { "Hello,World!" })))
-            .finish()
-    })
-    .bind("127.0.0.1:8080")?
-    .run()
-    .wait()
+    let app = App::new()
+        .at("/", get(handler_service(|| async { "Hello,World!" })))
+        .finish();
+
+    HttpServer::serve(app).bind("127.0.0.1:8080")?.run().wait()
 }

--- a/examples/multipart/src/main.rs
+++ b/examples/multipart/src/main.rs
@@ -14,12 +14,12 @@ use xitca_web::{
 
 fn main() -> io::Result<()> {
     tracing_subscriber::fmt().with_env_filter("[xitca-logger]=info").init();
-    HttpServer::new(|| {
+    HttpServer::serve(
         App::new()
             .at("/", post(handler_service(root)))
             .enclosed_fn(error_handler)
-            .finish()
-    })
+            .finish(),
+    )
     .bind("127.0.0.1:8080")?
     .run()
     .wait()

--- a/examples/multipart/src/main.rs
+++ b/examples/multipart/src/main.rs
@@ -9,20 +9,18 @@ use xitca_web::{
     handler::{handler_service, multipart::Multipart, Responder},
     request::WebRequest,
     route::post,
-    App, HttpServer,
+    App,
 };
 
 fn main() -> io::Result<()> {
     tracing_subscriber::fmt().with_env_filter("[xitca-logger]=info").init();
-    HttpServer::serve(
-        App::new()
-            .at("/", post(handler_service(root)))
-            .enclosed_fn(error_handler)
-            .finish(),
-    )
-    .bind("127.0.0.1:8080")?
-    .run()
-    .wait()
+    App::new()
+        .at("/", post(handler_service(root)))
+        .enclosed_fn(error_handler)
+        .serve()
+        .bind("127.0.0.1:8080")?
+        .run()
+        .wait()
 }
 
 async fn root(multipart: Multipart<'_>) -> Result<&'static str, Box<dyn std::error::Error>> {

--- a/examples/sync/src/main.rs
+++ b/examples/sync/src/main.rs
@@ -1,11 +1,12 @@
 //! sync version of hello-world example in this repo.
 
-use xitca_web::{handler::handler_sync_service, route::get, App, HttpServer};
+use xitca_web::{handler::handler_sync_service, route::get, App};
 
 fn main() -> std::io::Result<()> {
-    let app = App::new()
+    App::new()
         .at("/", get(handler_sync_service(|| "Hello,World!")))
-        .finish();
-
-    HttpServer::serve(app).bind("127.0.0.1:8080")?.run().wait()
+        .serve()
+        .bind("127.0.0.1:8080")?
+        .run()
+        .wait()
 }

--- a/examples/sync/src/main.rs
+++ b/examples/sync/src/main.rs
@@ -3,12 +3,9 @@
 use xitca_web::{handler::handler_sync_service, route::get, App, HttpServer};
 
 fn main() -> std::io::Result<()> {
-    HttpServer::new(|| {
-        App::new()
-            .at("/", get(handler_sync_service(|| "Hello,World!")))
-            .finish()
-    })
-    .bind("127.0.0.1:8080")?
-    .run()
-    .wait()
+    let app = App::new()
+        .at("/", get(handler_sync_service(|| "Hello,World!")))
+        .finish();
+
+    HttpServer::serve(app).bind("127.0.0.1:8080")?.run().wait()
 }

--- a/examples/tower-http/src/main.rs
+++ b/examples/tower-http/src/main.rs
@@ -10,7 +10,7 @@ use xitca_web::{
 };
 
 fn main() -> std::io::Result<()> {
-    HttpServer::new(|| {
+    HttpServer::serve(
         App::new()
             .at(
                 // catch all request path and pass it to ServeDir service where the path is matched against file.
@@ -22,8 +22,8 @@ fn main() -> std::io::Result<()> {
             .enclosed(CompatMiddleware::new(CompressionLayer::new()))
             // a simple middleware to intercept empty path and replace it with index.html
             .enclosed_fn(path)
-            .finish()
-    })
+            .finish(),
+    )
     .bind("localhost:8080")?
     .run()
     .wait()

--- a/examples/tower-http/src/main.rs
+++ b/examples/tower-http/src/main.rs
@@ -6,27 +6,25 @@
 use tower_http::{compression::CompressionLayer, services::ServeDir};
 use xitca_web::{
     dev::service::Service, http::Uri, middleware::tower_http_compat::TowerHttpCompat as CompatMiddleware,
-    request::WebRequest, service::tower_http_compat::TowerHttpCompat as CompatBuild, App, HttpServer,
+    request::WebRequest, service::tower_http_compat::TowerHttpCompat as CompatBuild, App,
 };
 
 fn main() -> std::io::Result<()> {
-    HttpServer::serve(
-        App::new()
-            .at(
-                // catch all request path and pass it to ServeDir service where the path is matched against file.
-                "/*path",
-                // use CompatBuild to wrap tower-http service which would transform it to a xitca service.
-                CompatBuild::new(ServeDir::new("files")),
-            )
-            // use CompatMiddleware to wrap tower-http middleware layer which would transform it to a xitca middleware.
-            .enclosed(CompatMiddleware::new(CompressionLayer::new()))
-            // a simple middleware to intercept empty path and replace it with index.html
-            .enclosed_fn(path)
-            .finish(),
-    )
-    .bind("localhost:8080")?
-    .run()
-    .wait()
+    App::new()
+        .at(
+            // catch all request path and pass it to ServeDir service where the path is matched against file.
+            "/*path",
+            // use CompatBuild to wrap tower-http service which would transform it to a xitca service.
+            CompatBuild::new(ServeDir::new("files")),
+        )
+        // use CompatMiddleware to wrap tower-http middleware layer which would transform it to a xitca middleware.
+        .enclosed(CompatMiddleware::new(CompressionLayer::new()))
+        // a simple middleware to intercept empty path and replace it with index.html
+        .enclosed_fn(path)
+        .serve()
+        .bind("localhost:8080")?
+        .run()
+        .wait()
 }
 
 async fn path<Res, Err>(

--- a/examples/unix/src/main.rs
+++ b/examples/unix/src/main.rs
@@ -1,9 +1,9 @@
 //! A UnixDomain server returns Hello World String as Response.
 
-use xitca_web::{handler::handler_service, route::get, App, HttpServer};
+use xitca_web::{handler::handler_service, route::get, App};
 
 fn main() -> std::io::Result<()> {
-    let mut server = HttpServer::serve(App::new().at("/", get(handler_service(handler))).finish());
+    let mut server = App::new().at("/", get(handler_service(handler))).serve();
 
     #[cfg(unix)]
     {

--- a/examples/unix/src/main.rs
+++ b/examples/unix/src/main.rs
@@ -3,7 +3,7 @@
 use xitca_web::{handler::handler_service, route::get, App, HttpServer};
 
 fn main() -> std::io::Result<()> {
-    let mut server = HttpServer::new(|| App::new().at("/", get(handler_service(handler))).finish());
+    let mut server = HttpServer::serve(App::new().at("/", get(handler_service(handler))).finish());
 
     #[cfg(unix)]
     {

--- a/examples/wasi/src/main.rs
+++ b/examples/wasi/src/main.rs
@@ -12,13 +12,10 @@ fn main() -> io::Result<()> {
     // convert to tcp listener.
     let listener = unsafe { std::net::TcpListener::from_raw_fd(fd) };
 
-    // run server.
-    HttpServer::new(|| App::new().at("/", get(handler_service(index))).finish())
-        .listen(listener)?
-        .run()
-        .wait()
-}
+    let app = App::new()
+        .at("/", get(handler_service(|| async { "hello,wasi" })))
+        .finish();
 
-async fn index() -> &'static str {
-    "hello,wasi"
+    // run server.
+    HttpServer::serve(app).listen(listener)?.run().wait()
 }

--- a/examples/wasi/src/main.rs
+++ b/examples/wasi/src/main.rs
@@ -1,6 +1,6 @@
 use std::{io, os::wasi::io::FromRawFd};
 
-use xitca_web::{handler::handler_service, route::get, App, HttpServer};
+use xitca_web::{handler::handler_service, route::get, App};
 
 fn main() -> io::Result<()> {
     // get fd int from env.
@@ -12,10 +12,11 @@ fn main() -> io::Result<()> {
     // convert to tcp listener.
     let listener = unsafe { std::net::TcpListener::from_raw_fd(fd) };
 
-    let app = App::new()
-        .at("/", get(handler_service(|| async { "hello,wasi" })))
-        .finish();
-
     // run server.
-    HttpServer::serve(app).listen(listener)?.run().wait()
+    App::new()
+        .at("/", get(handler_service(|| async { "hello,wasi" })))
+        .serve()
+        .listen(listener)?
+        .run()
+        .wait()
 }

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> std::io::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter("xitca=info,websocket=info")
         .init();
-    HttpServer::new(|| App::new().at("/", get(handler_service(handler))).finish())
+    HttpServer::serve(App::new().at("/", get(handler_service(handler))).finish())
         .bind("127.0.0.1:8080")?
         .run()
         .wait()

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -9,14 +9,16 @@ use xitca_web::{
         websocket::{Message, WebSocket},
     },
     route::get,
-    App, HttpServer,
+    App,
 };
 
 fn main() -> std::io::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter("xitca=info,websocket=info")
         .init();
-    HttpServer::serve(App::new().at("/", get(handler_service(handler))).finish())
+    App::new()
+        .at("/", get(handler_service(handler)))
+        .serve()
         .bind("127.0.0.1:8080")?
         .run()
         .wait()

--- a/http/src/util/middleware/context_priv.rs
+++ b/http/src/util/middleware/context_priv.rs
@@ -148,7 +148,7 @@ where
 
 #[cfg(feature = "router")]
 mod router_impl {
-    use xitca_service::object::{BoxedServiceObject, ServiceObject};
+    use xitca_service::object::{BoxedServiceObject, BoxedSyncServiceObject, ServiceObject};
 
     use crate::util::service::router::{IntoObject, SyncMarker, UnSyncMarker};
 
@@ -178,8 +178,7 @@ mod router_impl {
         I: Service<Arg> + Send + Sync + 'static,
         I::Response: for<'c> Service<Context<'c, Req, C>, Response = Res, Error = Err> + 'static,
     {
-        type Object =
-            Box<dyn ServiceObject<Arg, Response = ContextObject<Req, C, Res, Err>, Error = I::Error> + Send + Sync>;
+        type Object = BoxedSyncServiceObject<Arg, ContextObject<Req, C, Res, Err>, I::Error>;
 
         fn into_object(inner: I) -> Self::Object {
             Box::new(Builder(inner, core::marker::PhantomData))

--- a/http/src/util/service/router_priv.rs
+++ b/http/src/util/service/router_priv.rs
@@ -5,8 +5,10 @@ use core::marker::PhantomData;
 use std::{borrow::Cow, collections::HashMap};
 
 use xitca_service::{
-    object::BoxedServiceObject, pipeline::PipelineE, ready::ReadyService, EnclosedFactory, EnclosedFnFactory,
-    FnService, Service,
+    object::{BoxedServiceObject, BoxedSyncServiceObject},
+    pipeline::PipelineE,
+    ready::ReadyService,
+    EnclosedFactory, EnclosedFnFactory, FnService, Service,
 };
 
 use crate::http::{BorrowReq, BorrowReqMut, Request, Uri};
@@ -230,14 +232,7 @@ where
     T: Service<Arg> + Send + Sync + 'static,
     T::Response: Service<Request<Ext>, Response = Res, Error = Err> + 'static,
 {
-    type Object = Box<
-        dyn xitca_service::object::ServiceObject<
-                Arg,
-                Response = BoxedServiceObject<Request<Ext>, Res, Err>,
-                Error = T::Error,
-            > + Send
-            + Sync,
-    >;
+    type Object = BoxedSyncServiceObject<Arg, BoxedServiceObject<Request<Ext>, Res, Err>, T::Error>;
 
     fn into_object(inner: T) -> Self::Object {
         Box::new(Builder(inner, PhantomData))

--- a/service/src/object.rs
+++ b/service/src/object.rs
@@ -46,3 +46,6 @@ where
 /// An often used type alias for boxed service object. used when Req type is not bound to any
 /// lifetime.
 pub type BoxedServiceObject<Req, Res, Err> = Box<dyn ServiceObject<Req, Response = Res, Error = Err>>;
+
+/// sync version of [BoxedServiceObject]
+pub type BoxedSyncServiceObject<Req, Res, Err> = Box<dyn ServiceObject<Req, Response = Res, Error = Err> + Send + Sync>;

--- a/service/src/service/mod.rs
+++ b/service/src/service/mod.rs
@@ -41,6 +41,20 @@ where
 }
 
 #[cfg(feature = "alloc")]
+impl<S, Req> Service<Req> for alloc::sync::Arc<S>
+where
+    S: Service<Req> + ?Sized,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+
+    #[inline]
+    async fn call(&self, req: Req) -> Result<Self::Response, Self::Error> {
+        Service::call(&**self, req).await
+    }
+}
+
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -266,7 +266,7 @@ mod test {
 
         let state = String::from("state");
 
-        let service = App::with_current_thread_state(state)
+        let service = App::with_state(state)
             .at("/", get(handler_service(handler)))
             .at(
                 "/stateless",

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -35,20 +35,10 @@ impl App {
         Self::with_async_state(|| ready(Ok(())))
     }
 
-    /// Construct App with a thread local state.
-    ///
-    /// State would still be shared among tasks on the same thread.
-    pub fn with_current_thread_state<C, Obj>(state: C) -> App<impl Fn() -> Ready<Result<C, Infallible>>, Router<Obj>>
-    where
-        C: Clone + 'static,
-    {
-        Self::with_async_state(move || ready(Ok(state.clone())))
-    }
-
     /// Construct App with a thread safe state.
     ///
     /// State would be shared among all tasks and worker threads.
-    pub fn with_multi_thread_state<C, Obj>(state: C) -> App<impl Fn() -> Ready<Result<C, Infallible>>, Router<Obj>>
+    pub fn with_state<C, Obj>(state: C) -> App<impl Fn() -> Ready<Result<C, Infallible>>, Router<Obj>>
     where
         C: Send + Sync + Clone + 'static,
     {

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -47,8 +47,9 @@ impl App {
 
     #[doc(hidden)]
     /// Construct App with async closure which it's output would be used as state.
-    pub fn with_async_state<CF, Obj>(ctx_factory: CF) -> App<CF, Router<Obj>>
-where {
+    /// async state is used to produce thread per core and/or non thread safe state copies.
+    /// The output state is not bound to `Send` and `Sync` auto traits.
+    pub fn with_async_state<CF, Obj>(ctx_factory: CF) -> App<CF, Router<Obj>> {
         App {
             ctx_factory,
             router: Router::new(),

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -21,7 +21,6 @@ use crate::{
     http::{Request, RequestExt},
     request::WebRequest,
     response::WebResponse,
-    server::HttpServer,
 };
 
 /// composed application type with router, stateful context and default middlewares.
@@ -125,10 +124,13 @@ where
             .enclosed(ContextBuilder::new(ctx_factory))
     }
 
+    #[cfg(feature = "__server")]
     /// Finish App build and serve is with [HttpServer]. No other App method can be called afterwards.
+    ///
+    /// [HttpServer]: crate::server::HttpServer
     pub fn serve<C, Fut, CErr, ReqB, ResB, E, Err>(
         self,
-    ) -> HttpServer<
+    ) -> crate::server::HttpServer<
         impl Service<
             Response = impl ReadyService
                            + Service<Request<RequestExt<ReqB>>, Response = WebResponse<ResponseBody<ResB>>, Error = Err>,
@@ -148,7 +150,7 @@ where
         ResB: Stream<Item = Result<Bytes, E>> + 'static,
         E: 'static,
     {
-        HttpServer::serve(self.finish())
+        crate::server::HttpServer::serve(self.finish())
     }
 }
 

--- a/web/src/app/object.rs
+++ b/web/src/app/object.rs
@@ -1,7 +1,10 @@
 use core::marker::PhantomData;
 
 use xitca_http::util::service::router::{IntoObject, SyncMarker};
-use xitca_service::{object::ServiceObject, Service};
+use xitca_service::{
+    object::{BoxedSyncServiceObject, ServiceObject},
+    Service,
+};
 
 use crate::request::WebRequest;
 
@@ -14,7 +17,7 @@ where
     I: Service + Send + Sync + 'static,
     I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
 {
-    type Object = Box<dyn ServiceObject<(), Response = WebObject<C, B, Res, Err>, Error = I::Error> + Send + Sync>;
+    type Object = BoxedSyncServiceObject<(), WebObject<C, B, Res, Err>, I::Error>;
 
     fn into_object(inner: I) -> Self::Object {
         Box::new(Builder(inner, PhantomData))

--- a/web/src/handler/mod.rs
+++ b/web/src/handler/mod.rs
@@ -2,11 +2,16 @@
 
 mod error;
 mod impls;
-mod sync;
 mod types;
+
+// TODO: enable sync handler when major wasm targets(including wasi) support std threads
+#[cfg(not(target_family = "wasm"))]
+mod sync;
 
 pub use error::ExtractError;
 pub use types::*;
 
+#[cfg(not(target_family = "wasm"))]
 pub use sync::handler_sync_service;
+
 pub use xitca_http::util::service::handler::{handler_service, FromRequest, Responder};

--- a/web/src/handler/types/state.rs
+++ b/web/src/handler/types/state.rs
@@ -124,7 +124,7 @@ mod test {
             field2: 996,
         };
 
-        App::with_current_thread_state(state)
+        App::with_state(state)
             .at("/", get(handler_service(handler)))
             .finish()
             .call(())

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -30,7 +30,7 @@ pub mod codegen {
     ///
     /// # async fn app() {
     /// // construct App with MyState type.
-    /// App::with_current_thread_state(MyState { field: 996 })
+    /// App::with_state(MyState { field: 996 })
     ///     .at("/", handler_service(index))
     /// #   .at("/nah", handler_service(nah));
     /// # }

--- a/web/src/middleware/tower_http_compat.rs
+++ b/web/src/middleware/tower_http_compat.rs
@@ -149,7 +149,7 @@ mod test {
 
     #[test]
     fn tower_set_status() {
-        let res = App::with_current_thread_state("996")
+        let res = App::with_state("996")
             .at("/", fn_service(handler))
             .enclosed(TowerHttpCompat::new(SetStatusLayer::new(StatusCode::NOT_FOUND)))
             .finish()

--- a/web/src/middleware/tower_http_compat.rs
+++ b/web/src/middleware/tower_http_compat.rs
@@ -24,7 +24,7 @@ use crate::{
 /// Any `tower-http` type that impl [Layer] trait can be passed to it and used as xitca-web's middleware.
 pub struct TowerHttpCompat<L, C, ReqB, ResB, Err> {
     layer: L,
-    _phantom: PhantomData<(C, ReqB, ResB, Err)>,
+    _phantom: PhantomData<fn(C, ReqB, ResB, Err)>,
 }
 
 impl<L, C, ReqB, ResB, Err> Clone for TowerHttpCompat<L, C, ReqB, ResB, Err>
@@ -91,7 +91,7 @@ where
 
 pub struct CompatLayer<S, C, ReqB, ResB, Err> {
     service: Rc<S>,
-    _phantom: PhantomData<(C, ReqB, ResB, Err)>,
+    _phantom: PhantomData<fn(C, ReqB, ResB, Err)>,
 }
 
 impl<S, C, ReqB, ResB, Err> tower_service::Service<Request<CompatBody<FakeSend<RequestExt<ReqB>>>>>


### PR DESCRIPTION
Introducing `HttpServer::serve` API for directly accept an App instance when constructing the application.
Remove `HttpServer::new` and `App::new_current_thread_state` API.