### PR TITLE
remove closure from xitca_server::Builder.

### DIFF
--- a/examples/grpc/src/main.rs
+++ b/examples/grpc/src/main.rs
@@ -25,11 +25,13 @@ fn main() -> std::io::Result<()> {
         .with_env_filter("xitca=info,[xitca-logger]=trace")
         .init();
     xitca_server::Builder::new()
-        .bind("http/2", "localhost:50051", || {
+        .bind(
+            "http/2",
+            "localhost:50051",
             Router::new()
                 .insert("/helloworld.Greeter/SayHello", post(fn_service(grpc)))
-                .enclosed(HttpServiceBuilder::h2())
-        })?
+                .enclosed(HttpServiceBuilder::h2()),
+        )?
         .build()
         .wait()
 }

--- a/examples/io-uring/src/main.rs
+++ b/examples/io-uring/src/main.rs
@@ -14,15 +14,16 @@ use xitca_http::{
 use xitca_service::{fn_service, ServiceExt};
 
 fn main() -> io::Result<()> {
-    let config = tls_config();
     xitca_server::Builder::new()
-        .bind("http/1", "127.0.0.1:8080", move || {
+        .bind(
+            "http/1",
+            "127.0.0.1:8080",
             fn_service(handler).enclosed(
                 HttpServiceBuilder::h1()
                     .io_uring() // specify io_uring flavor of http service.
-                    .rustls_uring(config.clone()), // specify io_uring flavor of tls.
-            )
-        })?
+                    .rustls_uring(tls_config()), // specify io_uring flavor of tls.
+            ),
+        )?
         .build()
         .wait()
 }

--- a/http/src/builder.rs
+++ b/http/src/builder.rs
@@ -36,7 +36,7 @@ pub struct HttpServiceBuilder<
 > {
     pub(crate) tls_factory: FA,
     pub(crate) config: HttpServiceConfig<HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>,
-    pub(crate) _body: PhantomData<(V, St)>,
+    pub(crate) _body: PhantomData<fn(V, St)>,
 }
 
 impl

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -20,7 +20,7 @@
 //! // xitca-http has to run inside a tcp/udp server.
 //! xitca_server::Builder::new()
 //!     // create http service with given name, socket address and service logic.
-//!     .bind("xitca-http", "localhost:0", || {
+//!     .bind("xitca-http", "localhost:0",
 //!         // a simple async function service produce hello world string as http response.
 //!         fn_service(|req: Request<RequestExt<RequestBody>>| async {
 //!             Ok::<Response<ResponseBody>, Infallible>(req.into_response("Hello,World!"))
@@ -28,7 +28,7 @@
 //!         // http service builder is a middleware take control of above function service
 //!         // and bridge tcp/udp transport with the http service.
 //!         .enclosed(HttpServiceBuilder::new())
-//!     })?
+//!     )?
 //!     .build()
 //! # ; Ok(())
 //! # }

--- a/http/src/util/service/mod.rs
+++ b/http/src/util/service/mod.rs
@@ -6,9 +6,7 @@ mod router_priv;
 
 #[cfg(feature = "router")]
 pub mod router {
-    pub use super::router_priv::{
-        IntoObject, MatchError, Params, PathGen, Router, RouterError, SyncMarker, UnSyncMarker,
-    };
+    pub use super::router_priv::{IntoObject, MatchError, Params, PathGen, Router, RouterError};
 }
 
 #[cfg(feature = "router")]

--- a/http/src/util/service/router_priv.rs
+++ b/http/src/util/service/router_priv.rs
@@ -50,22 +50,9 @@ impl<Obj> Router<Obj> {
     /// When multiple services inserted to the same path.
     pub fn insert<F, Arg, Req>(mut self, path: &'static str, mut factory: F) -> Self
     where
-        F: Service<Arg> + PathGen,
-        F::Response: Service<Req>,
-        Req: IntoObject<F, Arg, UnSyncMarker, Object = Obj>,
-    {
-        let path = factory.gen(path);
-        assert!(self.routes.insert(path, Req::into_object(factory)).is_none());
-        self
-    }
-
-    /// sync version of [Router::insert] where the service factory type must be a thread safe
-    /// type that is bound to `Send` and `Sync` auto traits.
-    pub fn insert_sync<F, Arg, Req>(mut self, path: &'static str, mut factory: F) -> Self
-    where
         F: Service<Arg> + PathGen + Send + Sync,
         F::Response: Service<Req>,
-        Req: IntoObject<F, Arg, SyncMarker, Object = Obj>,
+        Req: IntoObject<F, Arg, Object = Obj>,
     {
         let path = factory.gen(path);
         assert!(self.routes.insert(path, Req::into_object(factory)).is_none());
@@ -187,10 +174,7 @@ impl<S> ReadyService for RouterService<S> {
 /// A [Service] type, for example, may be type-erased into `Box<dyn Service<&'static str>>`,
 /// `Box<dyn for<'a> Service<&'a str>>`, `Box<dyn Service<&'static str> + Service<u8>>`, etc.
 /// Each would be a separate impl for [IntoObject].
-pub trait IntoObject<I, Arg, M>
-where
-    M: _seal::Marker,
-{
+pub trait IntoObject<I, Arg> {
     /// The type-erased form of `I`.
     type Object;
 
@@ -198,35 +182,7 @@ where
     fn into_object(inner: I) -> Self::Object;
 }
 
-/// object marker that bound Router's routes to Send and Sync.
-pub struct SyncMarker;
-
-// object marker that bound Router's routes to !Send and !Sync.
-pub struct UnSyncMarker;
-
-mod _seal {
-    use super::{SyncMarker, UnSyncMarker};
-
-    pub trait Marker {}
-
-    impl Marker for SyncMarker {}
-    impl Marker for UnSyncMarker {}
-}
-
-impl<T, Arg, Ext, Res, Err> IntoObject<T, Arg, UnSyncMarker> for Request<Ext>
-where
-    Ext: 'static,
-    T: Service<Arg> + 'static,
-    T::Response: Service<Request<Ext>, Response = Res, Error = Err> + 'static,
-{
-    type Object = BoxedServiceObject<Arg, BoxedServiceObject<Request<Ext>, Res, Err>, T::Error>;
-
-    fn into_object(inner: T) -> Self::Object {
-        Box::new(Builder(inner, PhantomData))
-    }
-}
-
-impl<T, Arg, Ext, Res, Err> IntoObject<T, Arg, SyncMarker> for Request<Ext>
+impl<T, Arg, Ext, Res, Err> IntoObject<T, Arg> for Request<Ext>
 where
     Ext: 'static,
     T: Service<Arg> + Send + Sync + 'static,
@@ -235,22 +191,22 @@ where
     type Object = BoxedSyncServiceObject<Arg, BoxedServiceObject<Request<Ext>, Res, Err>, T::Error>;
 
     fn into_object(inner: T) -> Self::Object {
+        struct Builder<T, Req>(T, PhantomData<fn(Req)>);
+
+        impl<T, Req, Arg, Res, Err> Service<Arg> for Builder<T, Req>
+        where
+            T: Service<Arg> + 'static,
+            T::Response: Service<Req, Response = Res, Error = Err> + 'static,
+        {
+            type Response = BoxedServiceObject<Req, Res, Err>;
+            type Error = T::Error;
+
+            async fn call(&self, arg: Arg) -> Result<Self::Response, Self::Error> {
+                self.0.call(arg).await.map(|s| Box::new(s) as _)
+            }
+        }
+
         Box::new(Builder(inner, PhantomData))
-    }
-}
-
-struct Builder<T, Req>(T, PhantomData<fn(Req)>);
-
-impl<T, Req, Arg, Res, Err> Service<Arg> for Builder<T, Req>
-where
-    T: Service<Arg> + 'static,
-    T::Response: Service<Req, Response = Res, Error = Err> + 'static,
-{
-    type Response = BoxedServiceObject<Req, Res, Err>;
-    type Error = T::Error;
-
-    async fn call(&self, arg: Arg) -> Result<Self::Response, Self::Error> {
-        self.0.call(arg).await.map(|s| Box::new(s) as _)
     }
 }
 
@@ -280,7 +236,7 @@ mod test {
         {
         }
 
-        bound_check(Router::new().insert_sync(
+        bound_check(Router::new().insert(
             "/",
             fn_service(|_: Request<RequestExt<()>>| async { Ok::<_, Infallible>(Response::new(())) }),
         ))

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -24,9 +24,7 @@ mod test {
     fn test_builder() {
         let listener = std::net::TcpListener::bind("localhost:0").unwrap();
         let _server = crate::builder::Builder::new()
-            .listen("test", listener, || {
-                fn_service(|_: TcpStream| async { Ok::<_, ()>(()) })
-            })
+            .listen("test", listener, fn_service(|_: TcpStream| async { Ok::<_, ()>(()) }))
             .build();
     }
 }

--- a/server/src/server/future.rs
+++ b/server/src/server/future.rs
@@ -29,7 +29,7 @@ impl ServerFuture {
     /// # #[tokio::main]
     /// # async fn main() {
     /// let mut server = Builder::new()
-    ///     .bind("test", "127.0.0.1:0", || fn_service(|_io: TcpStream| async { Ok::<_, ()>(())}))
+    ///     .bind("test", "127.0.0.1:0", fn_service(|_io: TcpStream| async { Ok::<_, ()>(())}))
     ///     .unwrap()
     ///     .build();
     ///

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -4,7 +4,7 @@ mod service;
 
 pub use self::{future::ServerFuture, handle::ServerHandle};
 
-pub(crate) use self::service::{BuildServiceFn, BuildServiceObj};
+pub(crate) use self::service::{IntoServiceObj, ServiceObj};
 
 use std::{
     io, mem,

--- a/service/src/service/function.rs
+++ b/service/src/service/function.rs
@@ -43,12 +43,14 @@ where
 ///
 /// [ServiceExt::enclosed]: super::ServiceExt::enclosed
 /// [ServiceExt::enclosed_fn]: super::ServiceExt::enclosed_fn
-pub fn fn_build_nop<Arg>() -> FnService<impl Fn(Arg) -> Ready<Result<Arg, Infallible>>> {
+pub fn fn_build_nop<Arg>() -> FnService<impl Fn(Arg) -> Ready<Result<Arg, Infallible>> + Clone> {
     fn_build(|arg| ready(Ok(arg)))
 }
 
 /// Shortcut for transform a given Fn into type impl [Service] trait.
-pub fn fn_service<F, Req, Fut, Res, Err>(f: F) -> FnService<impl Fn(()) -> Ready<Result<FnService<F>, Infallible>>>
+pub fn fn_service<F, Req, Fut, Res, Err>(
+    f: F,
+) -> FnService<impl Fn(()) -> Ready<Result<FnService<F>, Infallible>> + Clone>
 where
     F: Fn(Req) -> Fut + Clone,
     Fut: Future<Output = Result<Res, Err>>,

--- a/test/tests/h1.rs
+++ b/test/tests/h1.rs
@@ -20,7 +20,7 @@ use xitca_test::{test_h1_server, Error};
 
 #[tokio::test]
 async fn h1_get() -> Result<(), Error> {
-    let mut handle = test_h1_server(|| fn_service(handle))?;
+    let mut handle = test_h1_server(fn_service(handle))?;
 
     let server_url = format!("http://{}/", handle.ip_port_string());
 
@@ -43,7 +43,7 @@ async fn h1_get() -> Result<(), Error> {
 
 #[tokio::test]
 async fn h1_post() -> Result<(), Error> {
-    let mut handle = test_h1_server(|| fn_service(handle))?;
+    let mut handle = test_h1_server(fn_service(handle))?;
 
     let server_url = format!("http://{}/", handle.ip_port_string());
 
@@ -72,7 +72,7 @@ async fn h1_post() -> Result<(), Error> {
 
 #[tokio::test]
 async fn h1_drop_body_read() -> Result<(), Error> {
-    let mut handle = test_h1_server(|| fn_service(handle))?;
+    let mut handle = test_h1_server(fn_service(handle))?;
 
     let server_url = format!("http://{}/drop_body", handle.ip_port_string());
 
@@ -98,7 +98,7 @@ async fn h1_drop_body_read() -> Result<(), Error> {
 
 #[tokio::test]
 async fn h1_partial_body_read() -> Result<(), Error> {
-    let mut handle = test_h1_server(|| fn_service(handle))?;
+    let mut handle = test_h1_server(fn_service(handle))?;
 
     let server_url = format!("http://{}/partial_read", handle.ip_port_string());
 
@@ -124,7 +124,7 @@ async fn h1_partial_body_read() -> Result<(), Error> {
 
 #[tokio::test]
 async fn h1_close_connection() -> Result<(), Error> {
-    let mut handle = test_h1_server(|| fn_service(handle))?;
+    let mut handle = test_h1_server(fn_service(handle))?;
 
     let server_url = format!("http://{}/close_connection", handle.ip_port_string());
 
@@ -145,7 +145,7 @@ async fn h1_close_connection() -> Result<(), Error> {
 // If the default setting changed this test must be chagned to reflex it.
 #[tokio::test]
 async fn h1_request_too_large() -> Result<(), Error> {
-    let mut handle = test_h1_server(|| fn_service(handle))?;
+    let mut handle = test_h1_server(fn_service(handle))?;
 
     let server_url = format!("http://{}/", handle.ip_port_string());
 
@@ -180,7 +180,7 @@ async fn h1_request_too_large() -> Result<(), Error> {
 
 #[tokio::test]
 async fn h1_keepalive() -> Result<(), Error> {
-    let mut handle = test_h1_server(|| fn_service(handle))?;
+    let mut handle = test_h1_server(fn_service(handle))?;
 
     let mut stream = TcpStream::connect(handle.addr())?;
 

--- a/test/tests/h2.rs
+++ b/test/tests/h2.rs
@@ -13,7 +13,7 @@ use xitca_test::{test_h2_server, Error};
 
 #[tokio::test]
 async fn h2_get() -> Result<(), Error> {
-    let mut handle = test_h2_server(|| fn_service(handle))?;
+    let mut handle = test_h2_server(fn_service(handle))?;
 
     let server_url = format!("https://{}/", handle.ip_port_string());
 
@@ -36,7 +36,7 @@ async fn h2_get() -> Result<(), Error> {
 
 #[tokio::test]
 async fn h2_post() -> Result<(), Error> {
-    let mut handle = test_h2_server(|| fn_service(handle))?;
+    let mut handle = test_h2_server(fn_service(handle))?;
 
     let server_url = format!("https://{}/", handle.ip_port_string());
 
@@ -62,7 +62,7 @@ async fn h2_post() -> Result<(), Error> {
 
 #[tokio::test]
 async fn h2_keepalive() -> Result<(), Error> {
-    let mut handle = test_h2_server(|| fn_service(handle))?;
+    let mut handle = test_h2_server(fn_service(handle))?;
 
     let server_url = format!("https://{}/", handle.ip_port_string());
 

--- a/test/tests/h2_v2.rs
+++ b/test/tests/h2_v2.rs
@@ -31,13 +31,11 @@ async fn h2_v2_post() {
 
     let (tx, rx) = std::sync::mpsc::sync_channel(1);
     std::thread::spawn(move || {
-        let factory = || {
-            fn_service(|(stream, _): (TcpStream, SocketAddr)| {
-                h2::run(stream, fn_service(handler).call(()).now_or_panic().unwrap())
-            })
-        };
+        let service = fn_service(|(stream, _): (TcpStream, SocketAddr)| {
+            h2::run(stream, fn_service(handler).call(()).now_or_panic().unwrap())
+        });
         let server = xitca_server::Builder::new()
-            .bind("qa", "localhost:8080", factory)?
+            .bind("qa", "localhost:8080", service)?
             .build();
 
         tx.send(()).unwrap();

--- a/test/tests/h3.rs
+++ b/test/tests/h3.rs
@@ -11,7 +11,7 @@ use xitca_test::{test_h3_server, Error};
 
 #[tokio::test]
 async fn h3_get() -> Result<(), Error> {
-    let mut handle = test_h3_server(|| fn_service(handle))?;
+    let mut handle = test_h3_server(fn_service(handle))?;
 
     let c = Client::new();
     let server_url = format!("https://localhost:{}/", handle.addr().port());
@@ -33,7 +33,7 @@ async fn h3_get() -> Result<(), Error> {
 
 #[tokio::test]
 async fn h3_post() -> Result<(), Error> {
-    let mut handle = test_h3_server(|| fn_service(handle))?;
+    let mut handle = test_h3_server(fn_service(handle))?;
 
     let c = Client::new();
 

--- a/test/tests/websocket.rs
+++ b/test/tests/websocket.rs
@@ -8,7 +8,7 @@ use xitca_test::{test_h2_server, Error};
 
 #[tokio::test]
 async fn message() -> Result<(), Error> {
-    let mut handle = xitca_test::test_h1_server(|| fn_service(handler))?;
+    let mut handle = xitca_test::test_h1_server(fn_service(handler))?;
 
     let c = Client::new();
 
@@ -39,7 +39,7 @@ async fn message() -> Result<(), Error> {
 
 #[tokio::test]
 async fn message_h2() -> Result<(), Error> {
-    let mut handle = test_h2_server(|| fn_service(handler))?;
+    let mut handle = test_h2_server(fn_service(handler))?;
 
     let server_url = format!("wss://{}/", handle.ip_port_string());
 

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -10,7 +10,7 @@ use core::{
 use futures_core::stream::Stream;
 use xitca_http::util::{
     middleware::context::{Context, ContextBuilder},
-    service::router::{IntoObject, PathGen, Router, SyncMarker},
+    service::router::{IntoObject, PathGen, Router},
 };
 
 use crate::{
@@ -65,9 +65,9 @@ impl<CF, Obj> App<CF, Router<Obj>> {
         Fut: Future<Output = Result<C, E>>,
         F: PathGen + Service + Send + Sync,
         F::Response: for<'r> Service<WebRequest<'r, C, B>>,
-        for<'r> WebRequest<'r, C, B>: IntoObject<F, (), SyncMarker, Object = Obj>,
+        for<'r> WebRequest<'r, C, B>: IntoObject<F, (), Object = Obj>,
     {
-        self.router = self.router.insert_sync(path, factory);
+        self.router = self.router.insert(path, factory);
         self
     }
 }

--- a/web/src/app/object.rs
+++ b/web/src/app/object.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use xitca_http::util::service::router::{IntoObject, SyncMarker};
+use xitca_http::util::service::router::IntoObject;
 use xitca_service::{
     object::{BoxedSyncServiceObject, ServiceObject},
     Service,
@@ -10,7 +10,7 @@ use crate::request::WebRequest;
 
 pub type WebObject<C, B, Res, Err> = Box<dyn for<'r> ServiceObject<WebRequest<'r, C, B>, Response = Res, Error = Err>>;
 
-impl<C, B, I, Res, Err> IntoObject<I, (), SyncMarker> for WebRequest<'_, C, B>
+impl<C, B, I, Res, Err> IntoObject<I, ()> for WebRequest<'_, C, B>
 where
     C: 'static,
     B: 'static,
@@ -20,21 +20,21 @@ where
     type Object = BoxedSyncServiceObject<(), WebObject<C, B, Res, Err>, I::Error>;
 
     fn into_object(inner: I) -> Self::Object {
+        struct Builder<I, C, B>(I, PhantomData<fn(C, B)>);
+
+        impl<C, I, B, Res, Err> Service for Builder<I, C, B>
+        where
+            I: Service + 'static,
+            I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
+        {
+            type Response = WebObject<C, B, Res, Err>;
+            type Error = I::Error;
+
+            async fn call(&self, arg: ()) -> Result<Self::Response, Self::Error> {
+                self.0.call(arg).await.map(|s| Box::new(s) as _)
+            }
+        }
+
         Box::new(Builder(inner, PhantomData))
-    }
-}
-
-struct Builder<I, C, B>(I, PhantomData<fn(C, B)>);
-
-impl<C, I, B, Res, Err> Service for Builder<I, C, B>
-where
-    I: Service + 'static,
-    I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
-{
-    type Response = WebObject<C, B, Res, Err>;
-    type Error = I::Error;
-
-    async fn call(&self, arg: ()) -> Result<Self::Response, Self::Error> {
-        self.0.call(arg).await.map(|s| Box::new(s) as _)
     }
 }

--- a/web/src/server.rs
+++ b/web/src/server.rs
@@ -177,13 +177,12 @@ where
         ResB: Stream<Item = Result<Bytes, BE>> + 'static,
         BE: fmt::Debug + 'static,
     {
-        let service = self.service.clone();
         let config = self.config;
-        self.builder = self.builder.bind("xitca-web", addr, move || {
-            let service = service.clone();
-            service.enclosed(HttpServiceBuilder::with_config(config).with_logger())
-        })?;
-
+        let service = self
+            .service
+            .clone()
+            .enclosed(HttpServiceBuilder::with_config(config).with_logger());
+        self.builder = self.builder.bind("xitca-web", addr, service)?;
         Ok(self)
     }
 
@@ -196,13 +195,12 @@ where
         ResB: Stream<Item = Result<Bytes, BE>> + 'static,
         BE: fmt::Debug + 'static,
     {
-        let service = self.service.clone();
         let config = self.config;
-        self.builder = self.builder.listen("xitca-web", listener, move || {
-            let service = service.clone();
-            service.enclosed(HttpServiceBuilder::with_config(config).with_logger())
-        });
-
+        let service = self
+            .service
+            .clone()
+            .enclosed(HttpServiceBuilder::with_config(config).with_logger());
+        self.builder = self.builder.listen("xitca-web", listener, service);
         Ok(self)
     }
 
@@ -220,7 +218,6 @@ where
         ResB: Stream<Item = Result<Bytes, BE>> + 'static,
         BE: fmt::Debug + 'static,
     {
-        let service = self.service.clone();
         let config = self.config;
 
         const H11: &[u8] = b"\x08http/1.1";
@@ -252,14 +249,12 @@ where
 
         let acceptor = builder.build();
 
-        self.builder = self.builder.bind("xitca-web-openssl", addr, move || {
-            let service = service.clone();
-            service.enclosed(
-                HttpServiceBuilder::with_config(config)
-                    .openssl(acceptor.clone())
-                    .with_logger(),
-            )
-        })?;
+        let service = self
+            .service
+            .clone()
+            .enclosed(HttpServiceBuilder::with_config(config).openssl(acceptor).with_logger());
+
+        self.builder = self.builder.bind("xitca-web-openssl", addr, service)?;
 
         Ok(self)
     }
@@ -279,7 +274,6 @@ where
         ResB: Stream<Item = Result<Bytes, BE>> + 'static,
         BE: fmt::Debug + 'static,
     {
-        let service = self.service.clone();
         let service_config = self.config;
 
         #[cfg(feature = "http2")]
@@ -290,14 +284,13 @@ where
 
         let config = std::sync::Arc::new(config);
 
-        self.builder = self.builder.bind("xitca-web-rustls", addr, move || {
-            let service = service.clone();
-            service.enclosed(
-                HttpServiceBuilder::with_config(service_config)
-                    .rustls(config.clone())
-                    .with_logger(),
-            )
-        })?;
+        let service = self.service.clone().enclosed(
+            HttpServiceBuilder::with_config(service_config)
+                .rustls(config)
+                .with_logger(),
+        );
+
+        self.builder = self.builder.bind("xitca-web-rustls", addr, service)?;
 
         Ok(self)
     }
@@ -312,14 +305,12 @@ where
         ResB: Stream<Item = Result<Bytes, BE>> + 'static,
         BE: fmt::Debug + 'static,
     {
-        let service = self.service.clone();
         let config = self.config;
-
-        self.builder = self.builder.bind_unix("xitca-web", path, move || {
-            let service = service.clone();
-            service.enclosed(HttpServiceBuilder::with_config(config).with_logger())
-        })?;
-
+        let service = self
+            .service
+            .clone()
+            .enclosed(HttpServiceBuilder::with_config(config).with_logger());
+        self.builder = self.builder.bind_unix("xitca-web", path, service)?;
         Ok(self)
     }
 


### PR DESCRIPTION
further remove closure usage. xitca_server::Builder::bind_xxx and listen_xxx APIs now accept thread safe types bound to `Send` and `Sync` directly.

revert `xitca_http::ulti::service::router::IntoObject` trait change to not include marker type anymore. remove `Router::insert_sync` API and make `Router` only accept `Send` + `Sync` routes in all cases. In other word `Router` is always forced to be thread safe from now on.

update examples to reflex these changes.