### PR TITLE
use plain async function as ws callback.

### DIFF
--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -6,6 +6,3 @@ edition = "2021"
 
 [dependencies]
 xitca-web = { version = "0.1", features = ["websocket"] }
-
-tracing = { version = "0.1.40", default-features = false }
-tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -1,8 +1,5 @@
 //! A Http/1 server echos back websocket text message.
 
-use std::time::Duration;
-
-use tracing::{error, info};
 use xitca_web::{
     handler::{
         handler_service,
@@ -13,9 +10,6 @@ use xitca_web::{
 };
 
 fn main() -> std::io::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter("xitca=info,websocket=info")
-        .init();
     App::new()
         .at("/", get(handler_service(handler)))
         .serve()
@@ -26,17 +20,7 @@ fn main() -> std::io::Result<()> {
 
 async fn handler(mut ws: WebSocket) -> WebSocket {
     // config websocket.
-    ws
-        // interval of ping message sent to client.
-        .set_ping_interval(Duration::from_secs(5))
-        // max consecutive unanswered pings until server close connection
-        .set_max_unanswered_ping(2)
-        .on_msg(on_msg)
-        // async function that called when error occurred
-        .on_err(|e| async move { error!("{e}") })
-        // async function that called when closing websocket connection.
-        .on_close(|| async { info!("WebSocket connection closing") });
-
+    ws.on_msg(on_msg);
     // return the instance after configuration.
     ws
 }
@@ -45,7 +29,7 @@ async fn handler(mut ws: WebSocket) -> WebSocket {
 async fn on_msg(msg: Message, ctx: &mut Context) {
     // ignore non text message.
     if let Message::Text(txt) = msg {
-        info!("Got text message: {txt}");
+        println!("Got text message: {txt}");
         // echo back text.
         ctx.text(format!("Echo: {txt}")).await.unwrap();
     }


### PR DESCRIPTION
add `websocket::Context` type to avoid exposing `http-ws` sender details in `WebSocket` callbacks.
`WebSocket::on_msg` now only accept async function as `async fn on_msg(msg: Message, ctx: &mut Context)`