### PR TITLE
partial update to rustls 0.22

### DIFF
--- a/examples/io-uring/Cargo.toml
+++ b/examples/io-uring/Cargo.toml
@@ -9,5 +9,6 @@ xitca-http = { version = "0.1", features = ["io-uring", "router", "rustls-uring"
 xitca-server = { version = "0.1", features = ["io-uring"] }
 xitca-service = "0.1"
 
-rcgen = "0.10.0"
-rustls = "0.21"
+rcgen = "0.11.0"
+rustls = "0.22"
+rustls-pki-types = "1"

--- a/examples/io-uring/src/main.rs
+++ b/examples/io-uring/src/main.rs
@@ -5,7 +5,8 @@
 
 use std::{convert::Infallible, io, sync::Arc};
 
-use rustls::{Certificate, PrivateKey, ServerConfig};
+use rustls::ServerConfig;
+use rustls_pki_types::PrivateKeyDer;
 use xitca_http::{
     h1,
     http::{const_header_value::TEXT_UTF8, header::CONTENT_TYPE, Request, RequestExt, Response},
@@ -40,11 +41,10 @@ fn tls_config() -> Arc<ServerConfig> {
     let subject_alt_names = vec!["127.0.0.1".to_string(), "localhost".to_string()];
 
     let cert = rcgen::generate_simple_self_signed(subject_alt_names).unwrap();
-    let key = PrivateKey(cert.serialize_private_key_der());
-    let cert = vec![Certificate(cert.serialize_der().unwrap())];
+    let key = PrivateKeyDer::Pkcs8(cert.serialize_private_key_der().into());
+    let cert = vec![cert.serialize_der().unwrap().into()];
 
     let mut config = rustls::ServerConfig::builder()
-        .with_safe_defaults()
         .with_no_client_auth()
         .with_single_cert(cert, key)
         .unwrap();

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -42,7 +42,7 @@ tracing = { version = "0.1.40", default-features = false }
 openssl = { version = "0.10", optional = true }
 
 # rustls support
-rustls = { version = "0.21", optional = true }
+rustls = { version = "0.22", optional = true }
 
 # native tls support
 native-tls = { version = "0.2.7", features = ["alpn"], optional = true }

--- a/tls/Cargo.toml
+++ b/tls/Cargo.toml
@@ -10,4 +10,4 @@ rustls-uring = ["rustls", "xitca-io/runtime-uring"]
 [dependencies]
 xitca-io = { version = "0.1", features = ["runtime"] }
 
-rustls = { version = "0.21", optional = true }
+rustls = { version = "0.22", optional = true }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -63,7 +63,7 @@ xitca-server = { version = "0.1", optional = true }
 openssl-crate = { package = "openssl", version = "0.10", optional = true }
 
 # rustls
-rustls-crate = { package = "rustls", version = "0.21", optional = true }
+rustls-crate = { package = "rustls", version = "0.22", optional = true }
 
 # params, json and urlencoded shared
 serde = { version = "1", optional = true }


### PR DESCRIPTION
for http1 and http2 server side only. tls for http3 is blocked on quinn.