### PR TITLE
web types renaming.

### DIFF
--- a/examples/file/src/main.rs
+++ b/examples/file/src/main.rs
@@ -7,12 +7,10 @@ use xitca_web::{
     bytes::Bytes,
     dev::service::Service,
     handler::{handler_service, request::RequestRef, state::StateRef},
-    http::{Method, Uri},
+    http::{Method, Uri, WebResponse},
     middleware::compress::Compress,
-    request::WebRequest,
-    response::WebResponse,
     route::Route,
-    App,
+    App, WebContext,
 };
 
 fn main() -> std::io::Result<()> {
@@ -47,15 +45,15 @@ async fn index(RequestRef(req): RequestRef<'_>, StateRef(dir): StateRef<'_, Serv
 }
 
 // a type alias for web request with ServeDir as application state type attached to it.
-type Request<'a> = WebRequest<'a, ServeDir>;
+type Context<'a> = WebContext<'a, ServeDir>;
 
 async fn path<Res, Err>(
-    service: &impl for<'r> Service<Request<'r>, Response = Res, Error = Err>,
-    mut req: Request<'_>,
+    service: &impl for<'r> Service<Context<'r>, Response = Res, Error = Err>,
+    mut ctx: Context<'_>,
 ) -> Result<Res, Err> {
-    match req.req().uri().path() {
-        "/" | "" => *req.req_mut().uri_mut() = Uri::from_static("/index.html"),
+    match ctx.req().uri().path() {
+        "/" | "" => *ctx.req_mut().uri_mut() = Uri::from_static("/index.html"),
         _ => {}
     }
-    service.call(req).await
+    service.call(ctx).await
 }

--- a/examples/multipart/src/main.rs
+++ b/examples/multipart/src/main.rs
@@ -6,9 +6,8 @@ use tracing::info;
 use xitca_web::{
     dev::service::Service,
     handler::{handler_service, multipart::Multipart, Responder},
-    request::WebRequest,
     route::post,
-    App,
+    App, WebContext,
 };
 
 fn main() -> io::Result<()> {
@@ -45,13 +44,13 @@ async fn root(multipart: Multipart) -> Result<&'static str, Box<dyn std::error::
 }
 
 // an error handler that would catch root function's result type and transform it to response.
-async fn error_handler<S, C, B, Res, SErr, Err>(service: &S, mut req: WebRequest<'_, C, B>) -> Result<Res, Err>
+async fn error_handler<S, C, B, Res, SErr, Err>(service: &S, mut ctx: WebContext<'_, C, B>) -> Result<Res, Err>
 where
-    S: for<'r> Service<WebRequest<'r, C, B>, Response = Result<Res, SErr>, Error = Err>,
-    SErr: for<'r> Responder<WebRequest<'r, C, B>, Output = Res>,
+    S: for<'r> Service<WebContext<'r, C, B>, Response = Result<Res, SErr>, Error = Err>,
+    SErr: for<'r> Responder<WebContext<'r, C, B>, Output = Res>,
 {
-    match service.call(req.reborrow()).await? {
+    match service.call(ctx.reborrow()).await? {
         Ok(res) => Ok(res),
-        Err(err) => Ok(err.respond_to(req).await),
+        Err(err) => Ok(err.respond_to(ctx).await),
     }
 }

--- a/examples/tower-http/src/main.rs
+++ b/examples/tower-http/src/main.rs
@@ -6,7 +6,7 @@
 use tower_http::{compression::CompressionLayer, services::ServeDir};
 use xitca_web::{
     dev::service::Service, http::Uri, middleware::tower_http_compat::TowerHttpCompat as CompatMiddleware,
-    request::WebRequest, service::tower_http_compat::TowerHttpCompat as CompatBuild, App,
+    service::tower_http_compat::TowerHttpCompat as CompatBuild, App, WebContext,
 };
 
 fn main() -> std::io::Result<()> {
@@ -28,12 +28,12 @@ fn main() -> std::io::Result<()> {
 }
 
 async fn path<Res, Err>(
-    service: &impl for<'r> Service<WebRequest<'r>, Response = Res, Error = Err>,
-    mut req: WebRequest<'_>,
+    service: &impl for<'r> Service<WebContext<'r>, Response = Res, Error = Err>,
+    mut ctx: WebContext<'_>,
 ) -> Result<Res, Err> {
-    match req.req().uri().path() {
-        "/" | "" => *req.req_mut().uri_mut() = Uri::from_static("/index.html"),
+    match ctx.req().uri().path() {
+        "/" | "" => *ctx.req_mut().uri_mut() = Uri::from_static("/index.html"),
         _ => {}
     }
-    service.call(req).await
+    service.call(ctx).await
 }

--- a/web/src/app/object.rs
+++ b/web/src/app/object.rs
@@ -6,16 +6,16 @@ use xitca_service::{
     Service,
 };
 
-use crate::request::WebRequest;
+use crate::context::WebContext;
 
-pub type WebObject<C, B, Res, Err> = Box<dyn for<'r> ServiceObject<WebRequest<'r, C, B>, Response = Res, Error = Err>>;
+pub type WebObject<C, B, Res, Err> = Box<dyn for<'r> ServiceObject<WebContext<'r, C, B>, Response = Res, Error = Err>>;
 
-impl<C, B, I, Res, Err> IntoObject<I, ()> for WebRequest<'_, C, B>
+impl<C, B, I, Res, Err> IntoObject<I, ()> for WebContext<'_, C, B>
 where
     C: 'static,
     B: 'static,
     I: Service + Send + Sync + 'static,
-    I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
+    I::Response: for<'r> Service<WebContext<'r, C, B>, Response = Res, Error = Err> + 'static,
 {
     type Object = BoxedSyncServiceObject<(), WebObject<C, B, Res, Err>, I::Error>;
 
@@ -25,7 +25,7 @@ where
         impl<C, I, B, Res, Err> Service for Builder<I, C, B>
         where
             I: Service + 'static,
-            I::Response: for<'r> Service<WebRequest<'r, C, B>, Response = Res, Error = Err> + 'static,
+            I::Response: for<'r> Service<WebContext<'r, C, B>, Response = Res, Error = Err> + 'static,
         {
             type Response = WebObject<C, B, Res, Err>;
             type Error = I::Error;

--- a/web/src/handler/error.rs
+++ b/web/src/handler/error.rs
@@ -57,8 +57,8 @@ impl<E> From<Infallible> for ExtractError<E> {
 impl<'r, C, B, E> Responder<WebContext<'r, C, B>> for ExtractError<E> {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
-        let mut res = req.into_response(Bytes::new());
+    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Self::Output {
+        let mut res = ctx.into_response(Bytes::new());
         *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
         res
     }

--- a/web/src/handler/error.rs
+++ b/web/src/handler/error.rs
@@ -9,10 +9,9 @@ use serde_json::Error as JsonError;
 
 use crate::{
     bytes::Bytes,
+    context::WebContext,
     error::BodyError,
-    http::{header::HeaderName, StatusCode},
-    request::WebRequest,
-    response::WebResponse,
+    http::{header::HeaderName, StatusCode, WebResponse},
 };
 
 use super::Responder;
@@ -55,10 +54,10 @@ impl<E> From<Infallible> for ExtractError<E> {
     }
 }
 
-impl<'r, C, B, E> Responder<WebRequest<'r, C, B>> for ExtractError<E> {
+impl<'r, C, B, E> Responder<WebContext<'r, C, B>> for ExtractError<E> {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebRequest<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
         let mut res = req.into_response(Bytes::new());
         *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
         res

--- a/web/src/handler/impls.rs
+++ b/web/src/handler/impls.rs
@@ -25,8 +25,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(T::from_request(req).await)
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(T::from_request(ctx).await)
     }
 }
 
@@ -39,8 +39,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(T::from_request(req).await.ok())
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(T::from_request(ctx).await.ok())
     }
 }
 
@@ -53,8 +53,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(req)
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(ctx)
     }
 }
 
@@ -78,8 +78,8 @@ where
     type Output = Result<O, E>;
 
     #[inline]
-    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
-        Ok(self?.respond_to(req).await)
+    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Self::Output {
+        Ok(self?.respond_to(ctx).await)
     }
 }
 
@@ -105,8 +105,8 @@ macro_rules! text_utf8 {
         impl<'r, C, B> Responder<WebContext<'r, C, B>> for $type {
             type Output = WebResponse;
 
-            async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
-                let mut res = req.into_response(self);
+            async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Self::Output {
+                let mut res = ctx.into_response(self);
                 res.headers_mut().insert(CONTENT_TYPE, TEXT_UTF8);
                 res
             }
@@ -122,8 +122,8 @@ macro_rules! blank_internal {
         impl<'r, C, B> Responder<WebContext<'r, C, B>> for $type {
             type Output = WebResponse;
 
-            async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
-                let mut res = req.into_response(Bytes::new());
+            async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Self::Output {
+                let mut res = ctx.into_response(Bytes::new());
                 *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
                 res
             }
@@ -139,8 +139,8 @@ blank_internal!(Box<dyn error::Error + Send + Sync>);
 impl<'r, C, B> Responder<WebContext<'r, C, B>> for MatchError {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
-        let mut res = req.into_response(Bytes::new());
+    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Self::Output {
+        let mut res = ctx.into_response(Bytes::new());
         *res.status_mut() = StatusCode::NOT_FOUND;
         res
     }
@@ -149,8 +149,8 @@ impl<'r, C, B> Responder<WebContext<'r, C, B>> for MatchError {
 impl<'r, C, B> Responder<WebContext<'r, C, B>> for MethodNotAllowed {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
-        let mut res = req.into_response(Bytes::new());
+    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Self::Output {
+        let mut res = ctx.into_response(Bytes::new());
 
         let allowed = self.allowed_methods();
 

--- a/web/src/handler/impls.rs
+++ b/web/src/handler/impls.rs
@@ -5,61 +5,60 @@ use std::{error, io};
 use crate::{
     body::BodyStream,
     bytes::Bytes,
+    context::WebContext,
     error::{MatchError, MethodNotAllowed},
     http::{
         const_header_value::TEXT_UTF8,
         header::{ALLOW, CONTENT_TYPE},
-        StatusCode,
+        StatusCode, WebResponse,
     },
-    request::WebRequest,
-    response::WebResponse,
 };
 
 use super::{error::ExtractError, FromRequest, Responder};
 
-impl<'a, 'r, C, B, T, E> FromRequest<'a, WebRequest<'r, C, B>> for Result<T, E>
+impl<'a, 'r, C, B, T, E> FromRequest<'a, WebContext<'r, C, B>> for Result<T, E>
 where
     B: BodyStream,
-    T: for<'a2, 'r2> FromRequest<'a2, WebRequest<'r2, C, B>, Error = E>,
+    T: for<'a2, 'r2> FromRequest<'a2, WebContext<'r2, C, B>, Error = E>,
 {
     type Type<'b> = Result<T, E>;
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(T::from_request(req).await)
     }
 }
 
-impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for Option<T>
+impl<'a, 'r, C, B, T> FromRequest<'a, WebContext<'r, C, B>> for Option<T>
 where
     B: BodyStream,
-    T: for<'a2, 'r2> FromRequest<'a2, WebRequest<'r2, C, B>>,
+    T: for<'a2, 'r2> FromRequest<'a2, WebContext<'r2, C, B>>,
 {
     type Type<'b> = Option<T>;
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(T::from_request(req).await.ok())
     }
 }
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for &'a WebRequest<'a, C, B>
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for &'a WebContext<'a, C, B>
 where
     C: 'static,
     B: BodyStream + 'static,
 {
-    type Type<'b> = &'b WebRequest<'b, C, B>;
+    type Type<'b> = &'b WebContext<'b, C, B>;
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(req)
     }
 }
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for ()
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for ()
 where
     B: BodyStream,
 {
@@ -67,46 +66,46 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(_: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(_: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(())
     }
 }
 
-impl<'r, C, B, T, O, E> Responder<WebRequest<'r, C, B>> for Result<T, E>
+impl<'r, C, B, T, O, E> Responder<WebContext<'r, C, B>> for Result<T, E>
 where
-    T: for<'r2> Responder<WebRequest<'r2, C, B>, Output = O>,
+    T: for<'r2> Responder<WebContext<'r2, C, B>, Output = O>,
 {
     type Output = Result<O, E>;
 
     #[inline]
-    async fn respond_to(self, req: WebRequest<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
         Ok(self?.respond_to(req).await)
     }
 }
 
-impl<'r, C, B, ResB> Responder<WebRequest<'r, C, B>> for WebResponse<ResB> {
+impl<'r, C, B, ResB> Responder<WebContext<'r, C, B>> for WebResponse<ResB> {
     type Output = WebResponse<ResB>;
 
     #[inline]
-    async fn respond_to(self, _: WebRequest<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, _: WebContext<'r, C, B>) -> Self::Output {
         self
     }
 }
 
-impl<'r, C, B> Responder<WebRequest<'r, C, B>> for Infallible {
+impl<'r, C, B> Responder<WebContext<'r, C, B>> for Infallible {
     type Output = WebResponse;
 
-    async fn respond_to(self, _: WebRequest<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, _: WebContext<'r, C, B>) -> Self::Output {
         match self {}
     }
 }
 
 macro_rules! text_utf8 {
     ($type: ty) => {
-        impl<'r, C, B> Responder<WebRequest<'r, C, B>> for $type {
+        impl<'r, C, B> Responder<WebContext<'r, C, B>> for $type {
             type Output = WebResponse;
 
-            async fn respond_to(self, req: WebRequest<'r, C, B>) -> Self::Output {
+            async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
                 let mut res = req.into_response(self);
                 res.headers_mut().insert(CONTENT_TYPE, TEXT_UTF8);
                 res
@@ -120,10 +119,10 @@ text_utf8!(&'static str);
 
 macro_rules! blank_internal {
     ($type: ty) => {
-        impl<'r, C, B> Responder<WebRequest<'r, C, B>> for $type {
+        impl<'r, C, B> Responder<WebContext<'r, C, B>> for $type {
             type Output = WebResponse;
 
-            async fn respond_to(self, req: WebRequest<'r, C, B>) -> Self::Output {
+            async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
                 let mut res = req.into_response(Bytes::new());
                 *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
                 res
@@ -137,20 +136,20 @@ blank_internal!(Box<dyn error::Error>);
 blank_internal!(Box<dyn error::Error + Send>);
 blank_internal!(Box<dyn error::Error + Send + Sync>);
 
-impl<'r, C, B> Responder<WebRequest<'r, C, B>> for MatchError {
+impl<'r, C, B> Responder<WebContext<'r, C, B>> for MatchError {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebRequest<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
         let mut res = req.into_response(Bytes::new());
         *res.status_mut() = StatusCode::NOT_FOUND;
         res
     }
 }
 
-impl<'r, C, B> Responder<WebRequest<'r, C, B>> for MethodNotAllowed {
+impl<'r, C, B> Responder<WebContext<'r, C, B>> for MethodNotAllowed {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebRequest<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
         let mut res = req.into_response(Bytes::new());
 
         let allowed = self.allowed_methods();
@@ -174,16 +173,15 @@ impl<'r, C, B> Responder<WebRequest<'r, C, B>> for MethodNotAllowed {
 
 #[cfg(test)]
 mod test {
+    use xitca_http::BodyError;
     use xitca_unsafe_collection::futures::NowOrPanic;
-
-    use crate::{error::BodyError, request::WebRequest};
 
     use super::*;
 
     #[test]
     fn extract_default_impls() {
-        let mut req = WebRequest::new_test(());
-        let req = req.as_web_req();
+        let mut req = WebContext::new_test(());
+        let req = req.as_web_ctx();
 
         Option::<()>::from_request(&req).now_or_panic().unwrap().unwrap();
 
@@ -192,7 +190,7 @@ mod test {
             .unwrap()
             .unwrap();
 
-        <&WebRequest<'_>>::from_request(&req).now_or_panic().unwrap();
+        <&WebContext<'_>>::from_request(&req).now_or_panic().unwrap();
 
         <()>::from_request(&req).now_or_panic().unwrap();
     }

--- a/web/src/handler/sync.rs
+++ b/web/src/handler/sync.rs
@@ -24,8 +24,8 @@ use xitca_service::{fn_build, FnService, Service};
 /// #         {handler_service, handler_sync_service},
 /// #         uri::{UriOwn, UriRef},
 /// #     },
-/// #     request::WebRequest,
 /// #     App,
+/// #     WebContext
 /// # };
 ///
 /// App::new()
@@ -33,8 +33,8 @@ use xitca_service::{fn_build, FnService, Service};
 ///     // uncomment the line below would result in compile error.
 ///     // .at("/invalid1", handler_sync_service(|_: UriRef<'_>| { "uri ref is borrowed value" }))
 ///     // uncomment the line below would result in compile error.
-///     // .at("/invalid2", handler_sync_service(|_: &WebRequest<'_>| { "web request is borrowed value and not thread safe" }))
-///     # .at("/nah", handler_service(|_: &WebRequest<'_>| async { "" }));
+///     // .at("/invalid2", handler_sync_service(|_: &WebContext<'_>| { "web request is borrowed value and not thread safe" }))
+///     # .at("/nah", handler_service(|_: &WebContext<'_>| async { "" }));
 /// ```
 ///
 /// [handler_service]: super::handler_service

--- a/web/src/handler/types/body.rs
+++ b/web/src/handler/types/body.rs
@@ -16,7 +16,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(Body(req.take_body_ref()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(Body(ctx.take_body_ref()))
     }
 }

--- a/web/src/handler/types/body.rs
+++ b/web/src/handler/types/body.rs
@@ -2,13 +2,13 @@
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{error::ExtractError, FromRequest},
-    request::WebRequest,
 };
 
 pub struct Body<B>(pub B);
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for Body<B>
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for Body<B>
 where
     B: BodyStream + Default,
 {
@@ -16,7 +16,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(Body(req.take_body_ref()))
     }
 }

--- a/web/src/handler/types/extension.rs
+++ b/web/src/handler/types/extension.rs
@@ -4,9 +4,9 @@ use core::{fmt, ops::Deref};
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{error::ExtractError, FromRequest},
     http::Extensions,
-    request::WebRequest,
 };
 
 /// Extract immutable reference of element stored inside [Extensions]
@@ -26,7 +26,7 @@ impl<T> Deref for ExtensionRef<'_, T> {
     }
 }
 
-impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for ExtensionRef<'a, T>
+impl<'a, 'r, C, B, T> FromRequest<'a, WebContext<'r, C, B>> for ExtensionRef<'a, T>
 where
     T: Send + Sync + 'static,
     B: BodyStream,
@@ -35,7 +35,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let ext = req
             .req()
             .extensions()
@@ -62,7 +62,7 @@ impl<T> Deref for ExtensionOwn<T> {
     }
 }
 
-impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for ExtensionOwn<T>
+impl<'a, 'r, C, B, T> FromRequest<'a, WebContext<'r, C, B>> for ExtensionOwn<T>
 where
     T: Send + Sync + Clone + 'static,
     B: BodyStream,
@@ -71,7 +71,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let ext = req
             .req()
             .extensions()
@@ -93,7 +93,7 @@ impl Deref for ExtensionsRef<'_> {
     }
 }
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for ExtensionsRef<'a>
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for ExtensionsRef<'a>
 where
     B: BodyStream,
 {
@@ -101,7 +101,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(ExtensionsRef(req.req().extensions()))
     }
 }

--- a/web/src/handler/types/extension.rs
+++ b/web/src/handler/types/extension.rs
@@ -35,8 +35,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let ext = req
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        let ext = ctx
             .req()
             .extensions()
             .get::<T>()
@@ -71,8 +71,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let ext = req
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        let ext = ctx
             .req()
             .extensions()
             .get::<T>()
@@ -101,7 +101,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(ExtensionsRef(req.req().extensions()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(ExtensionsRef(ctx.req().extensions()))
     }
 }

--- a/web/src/handler/types/header.rs
+++ b/web/src/handler/types/header.rs
@@ -67,8 +67,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        req.req()
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        ctx.req()
             .headers()
             .get(&map_to_header_name::<HEADER_NAME>())
             .map(HeaderRef)

--- a/web/src/handler/types/header.rs
+++ b/web/src/handler/types/header.rs
@@ -4,9 +4,9 @@ use core::{fmt, ops::Deref};
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{error::ExtractError, FromRequest},
     http::header::{self, HeaderValue},
-    request::WebRequest,
 };
 
 macro_rules! const_header_name {
@@ -59,7 +59,7 @@ impl<const HEADER_NAME: usize> Deref for HeaderRef<'_, HEADER_NAME> {
     }
 }
 
-impl<'a, 'r, C, B, const HEADER_NAME: usize> FromRequest<'a, WebRequest<'r, C, B>> for HeaderRef<'a, HEADER_NAME>
+impl<'a, 'r, C, B, const HEADER_NAME: usize> FromRequest<'a, WebContext<'r, C, B>> for HeaderRef<'a, HEADER_NAME>
 where
     B: BodyStream,
 {
@@ -67,7 +67,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         req.req()
             .headers()
             .get(&map_to_header_name::<HEADER_NAME>())
@@ -84,8 +84,8 @@ mod test {
 
     #[test]
     fn extract_header() {
-        let mut req = WebRequest::new_test(());
-        let mut req = req.as_web_req();
+        let mut req = WebContext::new_test(());
+        let mut req = req.as_web_ctx();
         req.req_mut()
             .headers_mut()
             .insert(header::HOST, header::HeaderValue::from_static("996"));

--- a/web/src/handler/types/html.rs
+++ b/web/src/handler/types/html.rs
@@ -5,10 +5,9 @@ use core::fmt;
 use xitca_http::body::ResponseBody;
 
 use crate::{
+    context::WebContext,
     handler::Responder,
-    http::{const_header_value::TEXT_HTML_UTF8, header::CONTENT_TYPE},
-    request::WebRequest,
-    response::WebResponse,
+    http::{const_header_value::TEXT_HTML_UTF8, header::CONTENT_TYPE, WebResponse},
 };
 
 pub struct Html<T>(pub T);
@@ -22,14 +21,14 @@ where
     }
 }
 
-impl<'r, S, T> Responder<WebRequest<'r, S>> for Html<T>
+impl<'r, S, T> Responder<WebContext<'r, S>> for Html<T>
 where
     T: Into<ResponseBody>,
 {
     type Output = WebResponse;
 
     #[inline]
-    async fn respond_to(self, req: WebRequest<'r, S>) -> Self::Output {
+    async fn respond_to(self, req: WebContext<'r, S>) -> Self::Output {
         let mut res = req.into_response(self.0);
         res.headers_mut().insert(CONTENT_TYPE, TEXT_HTML_UTF8);
         res

--- a/web/src/handler/types/html.rs
+++ b/web/src/handler/types/html.rs
@@ -28,8 +28,8 @@ where
     type Output = WebResponse;
 
     #[inline]
-    async fn respond_to(self, req: WebContext<'r, S>) -> Self::Output {
-        let mut res = req.into_response(self.0);
+    async fn respond_to(self, ctx: WebContext<'r, S>) -> Self::Output {
+        let mut res = ctx.into_response(self.0);
         res.headers_mut().insert(CONTENT_TYPE, TEXT_HTML_UTF8);
         res
     }

--- a/web/src/handler/types/multipart.rs
+++ b/web/src/handler/types/multipart.rs
@@ -1,19 +1,20 @@
 use crate::{
     body::BodyStream,
+    body::RequestBody,
+    context::WebContext,
     handler::{error::ExtractError, FromRequest},
-    request::{RequestBody, WebRequest},
 };
 
 pub type Multipart<B = RequestBody> = http_multipart::Multipart<B>;
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for Multipart<B>
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for Multipart<B>
 where
     B: BodyStream + Default,
 {
     type Type<'b> = Multipart<B>;
     type Error = ExtractError<B::Error>;
 
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let body = req.take_body_ref();
         http_multipart::multipart(req.req(), body).map_err(Into::into)
     }

--- a/web/src/handler/types/multipart.rs
+++ b/web/src/handler/types/multipart.rs
@@ -14,9 +14,9 @@ where
     type Type<'b> = Multipart<B>;
     type Error = ExtractError<B::Error>;
 
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let body = req.take_body_ref();
-        http_multipart::multipart(req.req(), body).map_err(Into::into)
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        let body = ctx.take_body_ref();
+        http_multipart::multipart(ctx.req(), body).map_err(Into::into)
     }
 }
 

--- a/web/src/handler/types/params.rs
+++ b/web/src/handler/types/params.rs
@@ -28,10 +28,9 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let params = req.req().body().params();
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        let params = ctx.req().body().params();
         let params = T::deserialize(Params2::new(params)).map_err(_ParseError::Params)?;
-
         Ok(Params(params))
     }
 }
@@ -55,8 +54,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(ParamsRef(req.req().extensions().get::<router::Params>().unwrap()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(ParamsRef(ctx.req().extensions().get::<router::Params>().unwrap()))
     }
 }
 

--- a/web/src/handler/types/params.rs
+++ b/web/src/handler/types/params.rs
@@ -9,17 +9,17 @@ use xitca_http::util::service::router;
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{
         error::{ExtractError, _ParseError},
         FromRequest,
     },
-    request::WebRequest,
 };
 
 #[derive(Debug)]
 pub struct Params<T>(pub T);
 
-impl<'a, 'r, T, C, B> FromRequest<'a, WebRequest<'r, C, B>> for Params<T>
+impl<'a, 'r, T, C, B> FromRequest<'a, WebContext<'r, C, B>> for Params<T>
 where
     B: BodyStream,
     T: for<'de> Deserialize<'de>,
@@ -28,7 +28,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let params = req.req().body().params();
         let params = T::deserialize(Params2::new(params)).map_err(_ParseError::Params)?;
 
@@ -47,7 +47,7 @@ impl Deref for ParamsRef<'_> {
     }
 }
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for ParamsRef<'a>
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for ParamsRef<'a>
 where
     B: BodyStream,
 {
@@ -55,7 +55,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(ParamsRef(req.req().extensions().get::<router::Params>().unwrap()))
     }
 }

--- a/web/src/handler/types/path.rs
+++ b/web/src/handler/types/path.rs
@@ -27,8 +27,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(PathRef(req.req().uri().path()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(PathRef(ctx.req().uri().path()))
     }
 }
 
@@ -51,7 +51,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(PathOwn(req.req().uri().path().to_string()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(PathOwn(ctx.req().uri().path().to_string()))
     }
 }

--- a/web/src/handler/types/path.rs
+++ b/web/src/handler/types/path.rs
@@ -4,8 +4,8 @@ use core::ops::Deref;
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{error::ExtractError, FromRequest},
-    request::WebRequest,
 };
 
 #[derive(Debug)]
@@ -19,7 +19,7 @@ impl Deref for PathRef<'_> {
     }
 }
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for PathRef<'a>
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for PathRef<'a>
 where
     B: BodyStream,
 {
@@ -27,7 +27,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(PathRef(req.req().uri().path()))
     }
 }
@@ -43,7 +43,7 @@ impl Deref for PathOwn {
     }
 }
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for PathOwn
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for PathOwn
 where
     B: BodyStream,
 {
@@ -51,7 +51,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(PathOwn(req.req().uri().path().to_string()))
     }
 }

--- a/web/src/handler/types/query.rs
+++ b/web/src/handler/types/query.rs
@@ -33,9 +33,9 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let value =
-            serde_urlencoded::from_str(req.req().uri().query().unwrap_or_default()).map_err(_ParseError::UrlEncoded)?;
+            serde_urlencoded::from_str(ctx.req().uri().query().unwrap_or_default()).map_err(_ParseError::UrlEncoded)?;
         Ok(Query(value))
     }
 }

--- a/web/src/handler/types/query.rs
+++ b/web/src/handler/types/query.rs
@@ -6,11 +6,11 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{
         error::{ExtractError, _ParseError},
         FromRequest,
     },
-    request::WebRequest,
 };
 
 pub struct Query<T>(pub T);
@@ -24,7 +24,7 @@ where
     }
 }
 
-impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for Query<T>
+impl<'a, 'r, C, B, T> FromRequest<'a, WebContext<'r, C, B>> for Query<T>
 where
     T: DeserializeOwned,
     B: BodyStream,
@@ -33,7 +33,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let value =
             serde_urlencoded::from_str(req.req().uri().query().unwrap_or_default()).map_err(_ParseError::UrlEncoded)?;
         Ok(Query(value))
@@ -55,8 +55,8 @@ mod test {
 
     #[test]
     fn query() {
-        let mut req = WebRequest::new_test(());
-        let mut req = req.as_web_req();
+        let mut req = WebContext::new_test(());
+        let mut req = req.as_web_ctx();
 
         *req.req_mut().uri_mut() = Uri::from_static("/996/251/?id=dagongren");
 

--- a/web/src/handler/types/request.rs
+++ b/web/src/handler/types/request.rs
@@ -4,9 +4,9 @@ use core::ops::Deref;
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{error::ExtractError, FromRequest},
     http::{Request, RequestExt},
-    request::WebRequest,
 };
 
 #[derive(Debug)]
@@ -20,7 +20,7 @@ impl Deref for RequestRef<'_> {
     }
 }
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for RequestRef<'a>
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for RequestRef<'a>
 where
     B: BodyStream,
 {
@@ -28,7 +28,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(RequestRef(req.req()))
     }
 }

--- a/web/src/handler/types/request.rs
+++ b/web/src/handler/types/request.rs
@@ -28,7 +28,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(RequestRef(req.req()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(RequestRef(ctx.req()))
     }
 }

--- a/web/src/handler/types/state.rs
+++ b/web/src/handler/types/state.rs
@@ -4,8 +4,8 @@ use core::{borrow::Borrow, fmt, ops::Deref};
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{error::ExtractError, FromRequest},
-    request::WebRequest,
 };
 
 /// App state extractor.
@@ -32,7 +32,7 @@ impl<S> Deref for StateRef<'_, S> {
     }
 }
 
-impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for StateRef<'a, T>
+impl<'a, 'r, C, B, T> FromRequest<'a, WebContext<'r, C, B>> for StateRef<'a, T>
 where
     C: Borrow<T>,
     B: BodyStream,
@@ -42,7 +42,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(StateRef(req.state().borrow()))
     }
 }
@@ -71,7 +71,7 @@ impl<S> Deref for StateOwn<S> {
     }
 }
 
-impl<'a, 'r, C, B, T> FromRequest<'a, WebRequest<'r, C, B>> for StateOwn<T>
+impl<'a, 'r, C, B, T> FromRequest<'a, WebContext<'r, C, B>> for StateOwn<T>
 where
     C: Borrow<T>,
     B: BodyStream,
@@ -81,7 +81,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(StateOwn(req.state().borrow().clone()))
     }
 }
@@ -94,7 +94,7 @@ mod test {
     use xitca_http::Request;
     use xitca_unsafe_collection::futures::NowOrPanic;
 
-    use crate::{dev::service::Service, handler::handler_service, request::WebRequest, route::get, App};
+    use crate::{dev::service::Service, handler::handler_service, route::get, App};
 
     #[derive(State, Clone, Debug, Eq, PartialEq)]
     struct State {
@@ -108,7 +108,7 @@ mod test {
         StateRef(state): StateRef<'_, String>,
         StateRef(state2): StateRef<'_, u32>,
         StateRef(state3): StateRef<'_, State>,
-        req: &WebRequest<'_, State>,
+        req: &WebContext<'_, State>,
     ) -> String {
         assert_eq!("state", state);
         assert_eq!(&996, state2);

--- a/web/src/handler/types/state.rs
+++ b/web/src/handler/types/state.rs
@@ -42,8 +42,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(StateRef(req.state().borrow()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(StateRef(ctx.state().borrow()))
     }
 }
 
@@ -81,8 +81,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(StateOwn(req.state().borrow().clone()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(StateOwn(ctx.state().borrow().clone()))
     }
 }
 
@@ -108,12 +108,12 @@ mod test {
         StateRef(state): StateRef<'_, String>,
         StateRef(state2): StateRef<'_, u32>,
         StateRef(state3): StateRef<'_, State>,
-        req: &WebContext<'_, State>,
+        ctx: &WebContext<'_, State>,
     ) -> String {
         assert_eq!("state", state);
         assert_eq!(&996, state2);
-        assert_eq!(state, req.state().field1.as_str());
-        assert_eq!(state3, req.state());
+        assert_eq!(state, ctx.state().field1.as_str());
+        assert_eq!(state3, ctx.state());
         state.to_string()
     }
 

--- a/web/src/handler/types/string.rs
+++ b/web/src/handler/types/string.rs
@@ -1,13 +1,13 @@
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{
         error::{ExtractError, _ParseError},
         FromRequest,
     },
-    request::WebRequest,
 };
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for String
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for String
 where
     B: BodyStream + Default,
 {
@@ -15,7 +15,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let vec = Vec::from_request(req).await?;
         Ok(String::from_utf8(vec).map_err(|e| _ParseError::String(e.utf8_error()))?)
     }

--- a/web/src/handler/types/string.rs
+++ b/web/src/handler/types/string.rs
@@ -15,8 +15,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let vec = Vec::from_request(req).await?;
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        let vec = Vec::from_request(ctx).await?;
         Ok(String::from_utf8(vec).map_err(|e| _ParseError::String(e.utf8_error()))?)
     }
 }

--- a/web/src/handler/types/uri.rs
+++ b/web/src/handler/types/uri.rs
@@ -26,8 +26,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(UriRef(req.req().uri()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(UriRef(ctx.req().uri()))
     }
 }
 
@@ -50,7 +50,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        Ok(UriOwn(req.req().uri().clone()))
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        Ok(UriOwn(ctx.req().uri().clone()))
     }
 }

--- a/web/src/handler/types/uri.rs
+++ b/web/src/handler/types/uri.rs
@@ -2,9 +2,9 @@ use std::ops::Deref;
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{error::ExtractError, FromRequest},
     http::Uri,
-    request::WebRequest,
 };
 
 #[derive(Debug)]
@@ -18,7 +18,7 @@ impl Deref for UriRef<'_> {
     }
 }
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for UriRef<'a>
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for UriRef<'a>
 where
     B: BodyStream,
 {
@@ -26,7 +26,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(UriRef(req.req().uri()))
     }
 }
@@ -42,7 +42,7 @@ impl Deref for UriOwn {
     }
 }
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for UriOwn
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for UriOwn
 where
     B: BodyStream,
 {
@@ -50,7 +50,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(UriOwn(req.req().uri().clone()))
     }
 }

--- a/web/src/handler/types/vec.rs
+++ b/web/src/handler/types/vec.rs
@@ -15,8 +15,8 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let body = req.take_body_ref();
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        let body = ctx.take_body_ref();
 
         let mut body = pin!(body);
 
@@ -34,7 +34,7 @@ where
 impl<'r, C, B> Responder<WebContext<'r, C, B>> for Vec<u8> {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
-        req.into_response(self)
+    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Self::Output {
+        ctx.into_response(self)
     }
 }

--- a/web/src/handler/types/vec.rs
+++ b/web/src/handler/types/vec.rs
@@ -2,12 +2,12 @@ use core::{future::poll_fn, pin::pin};
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     handler::{error::ExtractError, FromRequest, Responder},
-    request::WebRequest,
-    response::WebResponse,
+    http::WebResponse,
 };
 
-impl<'a, 'r, C, B> FromRequest<'a, WebRequest<'r, C, B>> for Vec<u8>
+impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for Vec<u8>
 where
     B: BodyStream + Default,
 {
@@ -15,7 +15,7 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebRequest<'r, C, B>) -> Result<Self, Self::Error> {
+    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let body = req.take_body_ref();
 
         let mut body = pin!(body);
@@ -31,10 +31,10 @@ where
     }
 }
 
-impl<'r, C, B> Responder<WebRequest<'r, C, B>> for Vec<u8> {
+impl<'r, C, B> Responder<WebContext<'r, C, B>> for Vec<u8> {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebRequest<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
         req.into_response(self)
     }
 }

--- a/web/src/handler/types/websocket.rs
+++ b/web/src/handler/types/websocket.rs
@@ -150,9 +150,9 @@ where
     type Error = ExtractError<B::Error>;
 
     #[inline]
-    async fn from_request(req: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let body = req.take_body_ref();
-        let ws = http_ws::ws(req.req(), body)?;
+    async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
+        let body = ctx.take_body_ref();
+        let ws = http_ws::ws(ctx.req(), body)?;
         Ok(WebSocket::new(ws))
     }
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 mod app;
+mod context;
 #[cfg(feature = "__server")]
 mod server;
 
@@ -8,8 +9,6 @@ pub mod body;
 pub mod error;
 pub mod handler;
 pub mod middleware;
-pub mod request;
-pub mod response;
 pub mod service;
 pub mod test;
 
@@ -19,7 +18,7 @@ pub mod codegen {
     ///
     /// # Example:
     /// ```rust
-    /// # use xitca_web::{codegen::State, handler::{handler_service, state::StateRef}, request::WebRequest, App};
+    /// # use xitca_web::{codegen::State, handler::{handler_service, state::StateRef}, App, WebContext};
     ///
     /// // use derive macro and attribute to mark the field that can be extracted.
     /// #[derive(State, Clone)]
@@ -40,12 +39,26 @@ pub mod codegen {
     ///     assert_eq!(*num, 996);
     ///     num.to_string()
     /// }
-    /// # async fn nah(_: &WebRequest<'_, MyState>) -> &'static str {
+    /// # async fn nah(_: &WebContext<'_, MyState>) -> &'static str {
     /// #   // needed to infer the body type of request
     /// #   ""
     /// # }
     /// ```
     pub use xitca_codegen::State;
+}
+
+pub mod http {
+    //! http types
+
+    use super::body::{RequestBody, ResponseBody};
+
+    pub use xitca_http::http::*;
+
+    /// type alias for default request type xitca-web uses.
+    pub type WebRequest<B = RequestBody> = Request<RequestExt<B>>;
+
+    /// type alias for default response type xitca-web uses.
+    pub type WebResponse<B = ResponseBody> = Response<B>;
 }
 
 pub mod route {
@@ -59,8 +72,8 @@ pub mod dev {
 
 pub use app::{App, AppObject};
 pub use body::BodyStream;
+pub use context::WebContext;
 #[cfg(feature = "__server")]
 pub use server::HttpServer;
 
 pub use xitca_http::bytes;
-pub use xitca_http::http;

--- a/web/src/middleware/compress.rs
+++ b/web/src/middleware/compress.rs
@@ -5,8 +5,7 @@ use http_encoding::{encoder, Coder, ContentEncoding};
 use crate::{
     body::{BodyStream, NONE_BODY_HINT},
     dev::service::{ready::ReadyService, Service},
-    http::{header::HeaderMap, BorrowReq},
-    response::WebResponse,
+    http::{header::HeaderMap, BorrowReq, WebResponse},
 };
 
 /// A compress middleware look into [WebRequest]'s `Accept-Encoding` header and

--- a/web/src/middleware/decompress.rs
+++ b/web/src/middleware/decompress.rs
@@ -4,14 +4,13 @@ use http_encoding::{error::EncodingError, Coder};
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     dev::service::{pipeline::PipelineE, ready::ReadyService, Service},
     handler::Responder,
-    http::{const_header_value::TEXT_UTF8, header::CONTENT_TYPE, Request, StatusCode},
-    request::WebRequest,
-    response::WebResponse,
+    http::{const_header_value::TEXT_UTF8, header::CONTENT_TYPE, Request, StatusCode, WebResponse},
 };
 
-/// A decompress middleware look into [WebRequest]'s `Content-Encoding` header and
+/// A decompress middleware look into [WebContext]'s `Content-Encoding` header and
 /// apply according decompression to it according to enabled compress feature.
 /// `compress-x` feature must be enabled for this middleware to function correctly.
 #[derive(Clone)]
@@ -32,15 +31,15 @@ pub struct DecompressService<S> {
 
 pub type DecompressServiceError<E> = PipelineE<EncodingError, E>;
 
-impl<'r, S, C, B, Res, Err> Service<WebRequest<'r, C, B>> for DecompressService<S>
+impl<'r, S, C, B, Res, Err> Service<WebContext<'r, C, B>> for DecompressService<S>
 where
     B: BodyStream + Default,
-    S: for<'rs> Service<WebRequest<'rs, C, Coder<B>>, Response = Res, Error = Err>,
+    S: for<'rs> Service<WebContext<'rs, C, Coder<B>>, Response = Res, Error = Err>,
 {
     type Response = Res;
     type Error = DecompressServiceError<Err>;
 
-    async fn call(&self, mut req: WebRequest<'r, C, B>) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, mut req: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         let (parts, ext) = req.take_request().into_parts();
         let ctx = req.ctx;
         let (ext, body) = ext.replace_body(());
@@ -50,7 +49,7 @@ where
         let mut body = RefCell::new(decoder);
         let mut req = req.map(|_| ext);
 
-        let req = WebRequest::new(&mut req, &mut body, ctx);
+        let req = WebContext::new(&mut req, &mut body, ctx);
 
         self.service.call(req).await.map_err(DecompressServiceError::Second)
     }
@@ -68,10 +67,10 @@ where
     }
 }
 
-impl<'r, C, B> Responder<WebRequest<'r, C, B>> for EncodingError {
+impl<'r, C, B> Responder<WebContext<'r, C, B>> for EncodingError {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebRequest<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
         let mut res = req.into_response(format!("{self}"));
         res.headers_mut().insert(CONTENT_TYPE, TEXT_UTF8);
         *res.status_mut() = StatusCode::UNSUPPORTED_MEDIA_TYPE;
@@ -82,7 +81,7 @@ impl<'r, C, B> Responder<WebRequest<'r, C, B>> for EncodingError {
 #[cfg(test)]
 mod test {
     use http_encoding::{encoder, ContentEncoding};
-    use xitca_http::body::{Once, RequestBody};
+    use xitca_http::body::Once;
     use xitca_unsafe_collection::futures::NowOrPanic;
 
     use crate::{bytes::Bytes, http::header::CONTENT_ENCODING};
@@ -90,8 +89,7 @@ mod test {
     use crate::{
         body::ResponseBody,
         handler::handler_service,
-        http::{Request, RequestExt},
-        response::WebResponse,
+        http::{WebRequest, WebResponse},
         test::collect_body,
         App,
     };
@@ -112,6 +110,8 @@ mod test {
             "noop"
         }
 
+        let req = <WebRequest as Default>::default();
+
         App::new()
             .at("/", handler_service(noop))
             .enclosed(Decompress)
@@ -119,7 +119,7 @@ mod test {
             .call(())
             .now_or_panic()
             .unwrap()
-            .call(Request::new(RequestExt::<RequestBody>::default()))
+            .call(req)
             .now_or_panic()
             .ok()
             .unwrap();
@@ -127,7 +127,7 @@ mod test {
 
     #[test]
     fn plain() {
-        let req = Request::new(RequestExt::<()>::default().map_body(|_| Once::new(Q)));
+        let req = <WebRequest as Default>::default().map(|ext| ext.map_body(|_| Once::new(Q)));
         App::new()
             .at("/", handler_service(handler))
             .enclosed(Decompress)
@@ -173,8 +173,8 @@ mod test {
 
         let body = collect_body(body).now_or_panic().unwrap();
 
-        let mut req =
-            Request::new(Once::new(Bytes::from(body))).map(|body| RequestExt::<()>::default().map_body(|_| body));
+        let mut req = <WebRequest as Default>::default().map(|ext| ext.map_body(|_| Once::new(Bytes::from(body))));
+
         req.headers_mut()
             .insert(CONTENT_ENCODING, parts.headers.remove(CONTENT_ENCODING).unwrap());
 

--- a/web/src/middleware/decompress.rs
+++ b/web/src/middleware/decompress.rs
@@ -39,9 +39,9 @@ where
     type Response = Res;
     type Error = DecompressServiceError<Err>;
 
-    async fn call(&self, mut req: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
-        let (parts, ext) = req.take_request().into_parts();
-        let ctx = req.ctx;
+    async fn call(&self, mut ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+        let (parts, ext) = ctx.take_request().into_parts();
+        let ctx = ctx.ctx;
         let (ext, body) = ext.replace_body(());
         let req = Request::from_parts(parts, ());
 
@@ -49,9 +49,9 @@ where
         let mut body = RefCell::new(decoder);
         let mut req = req.map(|_| ext);
 
-        let req = WebContext::new(&mut req, &mut body, ctx);
+        let ctx = WebContext::new(&mut req, &mut body, ctx);
 
-        self.service.call(req).await.map_err(DecompressServiceError::Second)
+        self.service.call(ctx).await.map_err(DecompressServiceError::Second)
     }
 }
 

--- a/web/src/middleware/eraser.rs
+++ b/web/src/middleware/eraser.rs
@@ -83,8 +83,8 @@ where
     type Error = Err;
 
     #[inline]
-    async fn call(&self, req: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
-        let res = self.service.call(req).await?;
+    async fn call(&self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+        let res = self.service.call(ctx).await?;
         Ok(res.map(ResponseBody::box_stream))
     }
 }
@@ -135,11 +135,11 @@ mod test {
         Ok(WebResponse::new(Once::new(Bytes::new())))
     }
 
-    async fn middleware_fn<S, C, B, Err>(s: &S, req: WebContext<'_, C, B>) -> Result<WebResponse, Err>
+    async fn middleware_fn<S, C, B, Err>(s: &S, ctx: WebContext<'_, C, B>) -> Result<WebResponse, Err>
     where
         S: for<'r> Service<WebContext<'r, C, B>, Response = WebResponse, Error = Err>,
     {
-        s.call(req).await
+        s.call(ctx).await
     }
 
     #[test]

--- a/web/src/middleware/limit.rs
+++ b/web/src/middleware/limit.rs
@@ -12,11 +12,10 @@ use xitca_http::Request;
 
 use crate::{
     body::BodyStream,
+    context::WebContext,
     dev::service::{pipeline::PipelineE, ready::ReadyService, Service},
     handler::Responder,
-    http::{const_header_value::TEXT_UTF8, header::CONTENT_TYPE, status::StatusCode},
-    request::WebRequest,
-    response::WebResponse,
+    http::{const_header_value::TEXT_UTF8, header::CONTENT_TYPE, status::StatusCode, WebResponse},
 };
 
 #[derive(Copy, Clone)]
@@ -60,22 +59,22 @@ pub struct LimitService<S> {
 
 pub type LimitServiceError<E> = PipelineE<LimitError, E>;
 
-impl<'r, S, C, B, Res, Err> Service<WebRequest<'r, C, B>> for LimitService<S>
+impl<'r, S, C, B, Res, Err> Service<WebContext<'r, C, B>> for LimitService<S>
 where
     B: BodyStream + Default,
-    S: for<'r2> Service<WebRequest<'r2, C, LimitBody<B>>, Response = Res, Error = Err>,
+    S: for<'r2> Service<WebContext<'r2, C, LimitBody<B>>, Response = Res, Error = Err>,
 {
     type Response = Res;
     type Error = LimitServiceError<Err>;
 
-    async fn call(&self, mut req: WebRequest<'r, C, B>) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, mut req: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         let (parts, ext) = req.take_request().into_parts();
         let ctx = req.ctx;
         let (ext, body) = ext.replace_body(());
         let mut body = RefCell::new(LimitBody::new(body, self.limit.request_body_size));
         let mut req = Request::from_parts(parts, ext);
 
-        let req = WebRequest::new(&mut req, &mut body, ctx);
+        let req = WebContext::new(&mut req, &mut body, ctx);
 
         self.service.call(req).await.map_err(LimitServiceError::Second)
     }
@@ -160,10 +159,10 @@ impl fmt::Display for LimitError {
 
 impl error::Error for LimitError {}
 
-impl<'r, C, B> Responder<WebRequest<'r, C, B>> for LimitError {
+impl<'r, C, B> Responder<WebContext<'r, C, B>> for LimitError {
     type Output = WebResponse;
 
-    async fn respond_to(self, req: WebRequest<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
         let mut res = req.into_response(format!("{self}"));
         res.headers_mut().insert(CONTENT_TYPE, TEXT_UTF8);
         *res.status_mut() = StatusCode::BAD_REQUEST;

--- a/web/src/middleware/limit.rs
+++ b/web/src/middleware/limit.rs
@@ -67,16 +67,16 @@ where
     type Response = Res;
     type Error = LimitServiceError<Err>;
 
-    async fn call(&self, mut req: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
-        let (parts, ext) = req.take_request().into_parts();
-        let ctx = req.ctx;
+    async fn call(&self, mut ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+        let (parts, ext) = ctx.take_request().into_parts();
+        let ctx = ctx.ctx;
         let (ext, body) = ext.replace_body(());
         let mut body = RefCell::new(LimitBody::new(body, self.limit.request_body_size));
         let mut req = Request::from_parts(parts, ext);
 
-        let req = WebContext::new(&mut req, &mut body, ctx);
+        let ctx = WebContext::new(&mut req, &mut body, ctx);
 
-        self.service.call(req).await.map_err(LimitServiceError::Second)
+        self.service.call(ctx).await.map_err(LimitServiceError::Second)
     }
 }
 

--- a/web/src/middleware/tower_http_compat.rs
+++ b/web/src/middleware/tower_http_compat.rs
@@ -13,10 +13,9 @@ use tower_layer::Layer;
 use xitca_unsafe_collection::fake_send_sync::{FakeSend, FakeSync};
 
 use crate::{
+    context::WebContext,
     dev::service::Service,
-    http::{Request, RequestExt, Response},
-    request::WebRequest,
-    response::WebResponse,
+    http::{Request, RequestExt, Response, WebResponse},
     service::tower_http_compat::{CompatBody, TowerCompatService},
 };
 
@@ -49,7 +48,7 @@ impl<L, C, ReqB, ResB, Err> TowerHttpCompat<L, C, ReqB, ResB, Err> {
     /// # Example:
     /// ```rust
     /// # use std::convert::Infallible;
-    /// # use xitca_web::{dev::service::fn_service, request::WebRequest, response::WebResponse, App};
+    /// # use xitca_web::{dev::service::fn_service, http::WebResponse, App, WebContext};
     /// # use xitca_web::http::StatusCode;
     /// use xitca_web::middleware::tower_http_compat::TowerHttpCompat;
     /// use tower_http::set_status::SetStatusLayer;
@@ -60,7 +59,7 @@ impl<L, C, ReqB, ResB, Err> TowerHttpCompat<L, C, ReqB, ResB, Err> {
     ///     .enclosed(TowerHttpCompat::new(SetStatusLayer::new(StatusCode::NOT_FOUND)));
     /// # }
     ///
-    /// # async fn handler(req: WebRequest<'_>) -> Result<WebResponse, Infallible> {
+    /// # async fn handler(req: WebContext<'_>) -> Result<WebResponse, Infallible> {
     /// #   todo!()
     /// # }
     /// ```
@@ -75,7 +74,7 @@ impl<L, C, ReqB, ResB, Err> TowerHttpCompat<L, C, ReqB, ResB, Err> {
 impl<L, S, C, ReqB, ResB, Err> Service<S> for TowerHttpCompat<L, C, ReqB, ResB, Err>
 where
     L: Layer<CompatLayer<S, C, ReqB, ResB, Err>>,
-    S: for<'r> Service<WebRequest<'r, C, ReqB>, Response = WebResponse<ResB>, Error = Err>,
+    S: for<'r> Service<WebContext<'r, C, ReqB>, Response = WebResponse<ResB>, Error = Err>,
 {
     type Response = TowerCompatService<L::Service>;
     type Error = Infallible;
@@ -97,7 +96,7 @@ pub struct CompatLayer<S, C, ReqB, ResB, Err> {
 impl<S, C, ReqB, ResB, Err> tower_service::Service<Request<CompatBody<FakeSend<RequestExt<ReqB>>>>>
     for CompatLayer<S, C, ReqB, ResB, Err>
 where
-    S: for<'r> Service<WebRequest<'r, C, ReqB>, Response = WebResponse<ResB>, Error = Err> + 'static,
+    S: for<'r> Service<WebContext<'r, C, ReqB>, Response = WebResponse<ResB>, Error = Err> + 'static,
     C: Clone + 'static,
     ReqB: 'static,
 {
@@ -126,7 +125,7 @@ where
 
             let mut req = Request::from_parts(parts, ext);
             let mut body = RefCell::new(body);
-            let req = WebRequest::new(&mut req, &mut body, &ctx);
+            let req = WebContext::new(&mut req, &mut body, &ctx);
 
             service.call(req).await.map(|res| res.map(CompatBody::new))
         })
@@ -142,7 +141,7 @@ mod test {
 
     use super::*;
 
-    async fn handler(req: WebRequest<'_, &'static str>) -> Result<WebResponse, Infallible> {
+    async fn handler(req: WebContext<'_, &'static str>) -> Result<WebResponse, Infallible> {
         assert_eq!(*req.state(), "996");
         Ok(req.into_response(Bytes::new()))
     }

--- a/web/src/middleware/tower_http_compat.rs
+++ b/web/src/middleware/tower_http_compat.rs
@@ -59,7 +59,7 @@ impl<L, C, ReqB, ResB, Err> TowerHttpCompat<L, C, ReqB, ResB, Err> {
     ///     .enclosed(TowerHttpCompat::new(SetStatusLayer::new(StatusCode::NOT_FOUND)));
     /// # }
     ///
-    /// # async fn handler(req: WebContext<'_>) -> Result<WebResponse, Infallible> {
+    /// # async fn handler(ctx: WebContext<'_>) -> Result<WebResponse, Infallible> {
     /// #   todo!()
     /// # }
     /// ```
@@ -141,9 +141,9 @@ mod test {
 
     use super::*;
 
-    async fn handler(req: WebContext<'_, &'static str>) -> Result<WebResponse, Infallible> {
-        assert_eq!(*req.state(), "996");
-        Ok(req.into_response(Bytes::new()))
+    async fn handler(ctx: WebContext<'_, &'static str>) -> Result<WebResponse, Infallible> {
+        assert_eq!(*ctx.state(), "996");
+        Ok(ctx.into_response(Bytes::new()))
     }
 
     #[test]

--- a/web/src/response.rs
+++ b/web/src/response.rs
@@ -1,9 +1,0 @@
-//! web response types.
-
-pub use xitca_http::http::response::Builder as WebResponseBuilder;
-
-use xitca_http::http::Response;
-
-use super::body::ResponseBody;
-
-pub type WebResponse<B = ResponseBody> = Response<B>;

--- a/web/src/service/tower_http_compat.rs
+++ b/web/src/service/tower_http_compat.rs
@@ -16,10 +16,9 @@ use xitca_unsafe_collection::fake_send_sync::{FakeSend, FakeSync};
 
 use crate::{
     bytes::Buf,
+    context::WebContext,
     dev::service::{ready::ReadyService, Service},
-    http::{header::HeaderMap, Request, RequestExt, Response},
-    request::WebRequest,
-    response::WebResponse,
+    http::{header::HeaderMap, Request, RequestExt, Response, WebResponse},
 };
 
 /// A middleware type that bridge `xitca-service` and `tower-service`.
@@ -73,7 +72,7 @@ impl<S> TowerCompatService<S> {
     }
 }
 
-impl<'r, C, ReqB, S, ResB> Service<WebRequest<'r, C, ReqB>> for TowerCompatService<S>
+impl<'r, C, ReqB, S, ResB> Service<WebContext<'r, C, ReqB>> for TowerCompatService<S>
 where
     S: tower_service::Service<Request<CompatBody<FakeSend<RequestExt<ReqB>>>>, Response = Response<ResB>>,
     ResB: Body,
@@ -83,7 +82,7 @@ where
     type Response = WebResponse<CompatBody<ResB>>;
     type Error = S::Error;
 
-    async fn call(&self, mut req: WebRequest<'r, C, ReqB>) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, mut req: WebContext<'r, C, ReqB>) -> Result<Self::Response, Self::Error> {
         let ctx = req.state().clone();
         let (mut parts, ext) = req.take_request().into_parts();
         parts.extensions.insert(FakeSync::new(FakeSend::new(ctx)));

--- a/web/src/service/tower_http_compat.rs
+++ b/web/src/service/tower_http_compat.rs
@@ -82,10 +82,10 @@ where
     type Response = WebResponse<CompatBody<ResB>>;
     type Error = S::Error;
 
-    async fn call(&self, mut req: WebContext<'r, C, ReqB>) -> Result<Self::Response, Self::Error> {
-        let ctx = req.state().clone();
-        let (mut parts, ext) = req.take_request().into_parts();
-        parts.extensions.insert(FakeSync::new(FakeSend::new(ctx)));
+    async fn call(&self, mut ctx: WebContext<'r, C, ReqB>) -> Result<Self::Response, Self::Error> {
+        let state = ctx.state().clone();
+        let (mut parts, ext) = ctx.take_request().into_parts();
+        parts.extensions.insert(FakeSync::new(FakeSend::new(state)));
         let req = Request::from_parts(parts, CompatBody::new(FakeSend::new(ext)));
         let fut = tower_service::Service::call(&mut *self.service.borrow_mut(), req);
         fut.await.map(|res| res.map(CompatBody::new))


### PR DESCRIPTION
rename `WebRequest` type to `WebContext` for accurate naming. it's exported through `xitca_web::WebContext`.

remove `xitca_web::{request, response}` module and move their types into `xitca_web::http` module.

`WebRequest` and `WebResponse` type now are strictly type alias shortcut of their corresponding `xitca_http::http` types.