### PR TITLE
rework xitca_web error types.

### DIFF
--- a/http/src/body.rs
+++ b/http/src/body.rs
@@ -220,7 +220,7 @@ pin_project! {
 }
 
 impl ResponseBody {
-    /// Construct a new Stream variant of ResponseBody with default type as [BoxStream]
+    /// Construct a new Stream variant of ResponseBody with default type as [BoxBody]
     #[inline]
     pub fn box_stream<B, E>(stream: B) -> Self
     where

--- a/http/src/h1/proto/encode.rs
+++ b/http/src/h1/proto/encode.rs
@@ -226,7 +226,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        body::{BoxStream, Once},
+        body::{BoxBody, Once},
         bytes::Bytes,
         date::DateTimeService,
         http::{HeaderValue, Response},
@@ -241,7 +241,7 @@ mod test {
                 let date = DateTimeService::new();
                 let mut ctx = Context::<_, 64>::new(date.get());
 
-                let mut res = Response::new(BoxStream::new(Once::new(Bytes::new())));
+                let mut res = Response::new(BoxBody::new(Once::new(Bytes::new())));
 
                 res.headers_mut()
                     .insert(CONNECTION, HeaderValue::from_static("keep-alive"));

--- a/http/src/util/service/handler.rs
+++ b/http/src/util/service/handler.rs
@@ -1,6 +1,6 @@
 //! high level async function service with "variadic generic" ish.
 
-use core::{convert::Infallible, future::Future, marker::PhantomData, pin::Pin, mem};
+use core::{convert::Infallible, future::Future, marker::PhantomData, mem, pin::Pin};
 
 use xitca_service::{pipeline::PipelineE, AsyncClosure, Service};
 
@@ -189,9 +189,9 @@ where
     }
 }
 
-impl<I, Req> Responder<Req> for Box<I> 
+impl<I, Req> Responder<Req> for Box<I>
 where
-    I: ResponderDyn<Req> + ?Sized
+    I: ResponderDyn<Req> + ?Sized,
 {
     type Output = I::Output;
 

--- a/router/src/error.rs
+++ b/router/src/error.rs
@@ -73,13 +73,14 @@ impl InsertError {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 pub enum MatchError {
     /// The path was missing a trailing slash.
     MissingTrailingSlash,
     /// The path had an extra trailing slash.
     ExtraTrailingSlash,
     /// No matching route was found.
+    #[default]
     NotFound,
 }
 

--- a/test/tests/h1.rs
+++ b/test/tests/h1.rs
@@ -7,7 +7,7 @@ use std::{
 
 use xitca_client::Client;
 use xitca_http::{
-    body::{BoxStream, ResponseBody},
+    body::{BoxBody, ResponseBody},
     bytes::{Bytes, BytesMut},
     h1,
     http::{
@@ -228,7 +228,7 @@ async fn handle(req: Request<RequestExt<h1::RequestBody>>) -> Result<Response<Re
             let ty = req.headers().get(header::CONTENT_TYPE).unwrap().clone();
 
             let body = req.into_body();
-            let mut res = Response::new(ResponseBody::stream(BoxStream::new(body)));
+            let mut res = Response::new(ResponseBody::stream(BoxBody::new(body)));
 
             res.headers_mut().insert(header::CONTENT_LENGTH, length);
             res.headers_mut().insert(header::CONTENT_TYPE, ty);

--- a/web/src/body.rs
+++ b/web/src/body.rs
@@ -4,19 +4,19 @@ use std::error;
 
 use futures_core::stream::Stream;
 
-pub use xitca_http::body::{none_body_hint, BoxStream, RequestBody, ResponseBody, NONE_BODY_HINT};
+pub use xitca_http::body::{none_body_hint, BoxBody, RequestBody, ResponseBody, NONE_BODY_HINT};
 
 /// an extended trait for [Stream] that specify additional type info of the [Stream::Item] type.
 pub trait BodyStream: Stream<Item = Result<Self::Chunk, Self::Error>> {
     type Chunk: AsRef<[u8]> + 'static;
-    type Error: error::Error + 'static;
+    type Error: error::Error + Send + Sync + 'static;
 }
 
 impl<S, T, E> BodyStream for S
 where
     S: Stream<Item = Result<T, E>>,
     T: AsRef<[u8]> + 'static,
-    E: error::Error + 'static,
+    E: error::Error + Send + Sync + 'static,
 {
     type Chunk = T;
     type Error = E;

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -1,5 +1,9 @@
 //! web error types.
 
+use std::error;
+
+use xitca_http::util::service::handler::ResponderDyn;
+
 pub use xitca_http::{
     error::BodyError,
     util::service::{
@@ -7,3 +11,29 @@ pub use xitca_http::{
         router::{MatchError, RouterError},
     },
 };
+
+use super::{context::WebContext, http::WebResponse};
+
+pub type Error<C> = Box<dyn for<'r> ErrorResponder<WebContext<'r, C>>>;
+
+pub trait ErrorResponder<Req>: ResponderDyn<Req, Output = WebResponse> + error::Error + Send + Sync {}
+
+impl<E, Req> ErrorResponder<Req> for E where E: ResponderDyn<Req, Output = WebResponse> + error::Error + Send + Sync {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn trait_bound() {
+        use crate::error::MatchError;
+        let mut e = Box::new(MatchError::NotFound) as Error<()>;
+        println!("{e:?}");
+        println!("{e}");
+        let mut ctx = WebContext::new_test(());
+        let _ = e.respond_to(ctx.as_web_ctx());
+        // TODO: stable trait upcast stables at 1.76
+        // let e = &*e as &dyn std::error::Error;
+        // e.downcast_ref::<MatchError>().unwrap();
+    }
+}

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -14,26 +14,31 @@ pub use xitca_http::{
 
 use super::{context::WebContext, http::WebResponse};
 
+/// type erased error with additional formatting, type casting and [WebResponse] generation logic.
+///
+/// # Examples:
+/// ```rust
+/// # use xitca_http::util::service::handler::Responder;
+/// use xitca_web::{error::Error, http::WebResponse, WebContext};
+///
+/// async fn error_handle<C>(e: Error<C>, ctx: WebContext<'_, C>) -> WebResponse {
+///     // debug format error
+///     println!("{e:?}");
+///
+///     // display format error
+///     println!("{e}");
+///
+///     // note: trait upcasting feature is stabled in Rust 1.76.
+///     // type downcast for specified typed error handling.
+///     // if let Some(_) = (&*e as &dyn std::error::Error).downcast_ref::<std::convert::Infallible>() {
+///     // }
+///
+///     // generate http response from error
+///     e.respond_to(ctx).await
+/// }
+/// ```
 pub type Error<C> = Box<dyn for<'r> ErrorResponder<WebContext<'r, C>>>;
 
 pub trait ErrorResponder<Req>: ResponderDyn<Req, Output = WebResponse> + error::Error + Send + Sync {}
 
 impl<E, Req> ErrorResponder<Req> for E where E: ResponderDyn<Req, Output = WebResponse> + error::Error + Send + Sync {}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn trait_bound() {
-        use crate::error::MatchError;
-        let mut e = Box::new(MatchError::NotFound) as Error<()>;
-        println!("{e:?}");
-        println!("{e}");
-        let mut ctx = WebContext::new_test(());
-        let _ = e.respond_to(ctx.as_web_ctx());
-        // TODO: stable trait upcast stables at 1.76
-        // let e = &*e as &dyn std::error::Error;
-        // e.downcast_ref::<MatchError>().unwrap();
-    }
-}

--- a/web/src/handler/types/body.rs
+++ b/web/src/handler/types/body.rs
@@ -1,10 +1,6 @@
 //! type extractor for request body stream.
 
-use crate::{
-    body::BodyStream,
-    context::WebContext,
-    handler::{error::ExtractError, FromRequest},
-};
+use crate::{body::BodyStream, context::WebContext, error::Error, handler::FromRequest};
 
 pub struct Body<B>(pub B);
 
@@ -13,7 +9,7 @@ where
     B: BodyStream + Default,
 {
     type Type<'b> = Body<B>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/header.rs
+++ b/web/src/handler/types/header.rs
@@ -5,6 +5,7 @@ use core::{fmt, ops::Deref};
 use crate::{
     body::BodyStream,
     context::WebContext,
+    error::Error,
     handler::{error::ExtractError, FromRequest},
     http::header::{self, HeaderValue},
 };
@@ -64,7 +65,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = HeaderRef<'b, HEADER_NAME>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
@@ -72,7 +73,7 @@ where
             .headers()
             .get(&map_to_header_name::<HEADER_NAME>())
             .map(HeaderRef)
-            .ok_or_else(|| ExtractError::HeaderNotFound(map_to_header_name::<HEADER_NAME>()))
+            .ok_or_else(|| ExtractError::HeaderNotFound(map_to_header_name::<HEADER_NAME>()).into())
     }
 }
 

--- a/web/src/handler/types/multipart.rs
+++ b/web/src/handler/types/multipart.rs
@@ -1,8 +1,8 @@
 use crate::{
-    body::BodyStream,
-    body::RequestBody,
+    body::{BodyStream, RequestBody},
     context::WebContext,
-    handler::{error::ExtractError, FromRequest},
+    error::Error,
+    handler::{ExtractError, FromRequest},
 };
 
 pub type Multipart<B = RequestBody> = http_multipart::Multipart<B>;
@@ -12,11 +12,11 @@ where
     B: BodyStream + Default,
 {
     type Type<'b> = Multipart<B>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let body = ctx.take_body_ref();
-        http_multipart::multipart(ctx.req(), body).map_err(Into::into)
+        http_multipart::multipart(ctx.req(), body).map_err(|e| ExtractError::from(e).into())
     }
 }
 

--- a/web/src/handler/types/path.rs
+++ b/web/src/handler/types/path.rs
@@ -2,11 +2,7 @@
 
 use core::ops::Deref;
 
-use crate::{
-    body::BodyStream,
-    context::WebContext,
-    handler::{error::ExtractError, FromRequest},
-};
+use crate::{body::BodyStream, context::WebContext, error::Error, handler::FromRequest};
 
 #[derive(Debug)]
 pub struct PathRef<'a>(pub &'a str);
@@ -24,7 +20,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = PathRef<'b>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
@@ -48,7 +44,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = PathOwn;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/query.rs
+++ b/web/src/handler/types/query.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use crate::{
     body::BodyStream,
     context::WebContext,
+    error::Error,
     handler::{
         error::{ExtractError, _ParseError},
         FromRequest,
@@ -30,12 +31,12 @@ where
     B: BodyStream,
 {
     type Type<'b> = Query<T>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let value =
-            serde_urlencoded::from_str(ctx.req().uri().query().unwrap_or_default()).map_err(_ParseError::UrlEncoded)?;
+        let value = serde_urlencoded::from_str(ctx.req().uri().query().unwrap_or_default())
+            .map_err(|e| ExtractError::from(_ParseError::UrlEncoded(e)))?;
         Ok(Query(value))
     }
 }

--- a/web/src/handler/types/request.rs
+++ b/web/src/handler/types/request.rs
@@ -5,7 +5,8 @@ use core::ops::Deref;
 use crate::{
     body::BodyStream,
     context::WebContext,
-    handler::{error::ExtractError, FromRequest},
+    error::Error,
+    handler::FromRequest,
     http::{Request, RequestExt},
 };
 
@@ -25,7 +26,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = RequestRef<'b>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/state.rs
+++ b/web/src/handler/types/state.rs
@@ -2,11 +2,7 @@
 
 use core::{borrow::Borrow, fmt, ops::Deref};
 
-use crate::{
-    body::BodyStream,
-    context::WebContext,
-    handler::{error::ExtractError, FromRequest},
-};
+use crate::{body::BodyStream, context::WebContext, error::Error, handler::FromRequest};
 
 /// App state extractor.
 /// S type must be the same with the type passed to App::with_xxx_state(S).
@@ -39,7 +35,7 @@ where
     T: 'static,
 {
     type Type<'b> = StateRef<'b, T>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
@@ -78,7 +74,7 @@ where
     T: Clone,
 {
     type Type<'b> = StateOwn<T>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/string.rs
+++ b/web/src/handler/types/string.rs
@@ -1,6 +1,7 @@
 use crate::{
     body::BodyStream,
     context::WebContext,
+    error::Error,
     handler::{
         error::{ExtractError, _ParseError},
         FromRequest,
@@ -12,11 +13,11 @@ where
     B: BodyStream + Default,
 {
     type Type<'b> = String;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let vec = Vec::from_request(ctx).await?;
-        Ok(String::from_utf8(vec).map_err(|e| _ParseError::String(e.utf8_error()))?)
+        Ok(String::from_utf8(vec).map_err(|e| ExtractError::from(_ParseError::String(e.utf8_error())))?)
     }
 }

--- a/web/src/handler/types/uri.rs
+++ b/web/src/handler/types/uri.rs
@@ -1,11 +1,6 @@
 use std::ops::Deref;
 
-use crate::{
-    body::BodyStream,
-    context::WebContext,
-    handler::{error::ExtractError, FromRequest},
-    http::Uri,
-};
+use crate::{body::BodyStream, context::WebContext, error::Error, handler::FromRequest, http::Uri};
 
 #[derive(Debug)]
 pub struct UriRef<'a>(pub &'a Uri);
@@ -23,7 +18,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = UriRef<'b>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
@@ -47,7 +42,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = UriOwn;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/vec.rs
+++ b/web/src/handler/types/vec.rs
@@ -3,7 +3,8 @@ use core::{future::poll_fn, pin::pin};
 use crate::{
     body::BodyStream,
     context::WebContext,
-    handler::{error::ExtractError, FromRequest, Responder},
+    error::Error,
+    handler::{ExtractError, FromRequest, Responder},
     http::WebResponse,
 };
 
@@ -12,7 +13,7 @@ where
     B: BodyStream + Default,
 {
     type Type<'b> = Vec<u8>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
@@ -23,7 +24,7 @@ where
         let mut vec = Vec::new();
 
         while let Some(chunk) = poll_fn(|cx| body.as_mut().poll_next(cx)).await {
-            let chunk = chunk.map_err(ExtractError::Body)?;
+            let chunk = chunk.map_err(|e| ExtractError::Boxed(Box::new(e)))?;
             vec.extend_from_slice(chunk.as_ref());
         }
 


### PR DESCRIPTION
rename `xitca_http::body::BoxStream` to `BoxBody`.
add `xitca_web::error::Error` type for type erase error handling. all extractors now return `Error<C>` type instead of typed `ExtractError`.
