### PR TITLE
rework RouterError.

### DIFF
--- a/examples/cloudflare-worker/src/lib.rs
+++ b/examples/cloudflare-worker/src/lib.rs
@@ -15,7 +15,7 @@ use worker::*;
 use xitca_http::{
     http,
     util::service::{
-        route::{get, post, Route, RouteError},
+        route::{get, post, Route},
         router::{Router, RouterError},
     },
 };
@@ -190,13 +190,13 @@ async fn serve(mut req: HttpRequest) -> Result<Response> {
 // error handler middleware
 async fn error_handler<S>(service: &S, req: HttpRequest) -> Result<Response>
 where
-    S: Service<HttpRequest, Response = Response, Error = RouterError<RouteError<Error>>>,
+    S: Service<HttpRequest, Response = Response, Error = RouterError<Error>>,
 {
     match service.call(req).await {
         Ok(res) => Ok(res),
-        Err(RouterError::First(_)) => not_found(),
-        Err(RouterError::Second(RouteError::First(_))) => Response::error("MethodNotAllowed", 405),
-        Err(RouterError::Second(RouteError::Second(e))) => {
+        Err(RouterError::Match(_)) => not_found(),
+        Err(RouterError::NotAllowed(_)) => Response::error("MethodNotAllowed", 405),
+        Err(RouterError::Service(e)) => {
             console_log!("unhandled error: {e}");
             internal()
         }

--- a/http/src/util/service/mod.rs
+++ b/http/src/util/service/mod.rs
@@ -1,8 +1,10 @@
 pub mod handler;
-pub mod route;
 
 #[cfg(feature = "router")]
 mod router_priv;
+
+#[cfg(feature = "router")]
+pub mod route;
 
 #[cfg(feature = "router")]
 pub mod router {

--- a/http/src/util/service/router_priv.rs
+++ b/http/src/util/service/router_priv.rs
@@ -1,8 +1,8 @@
 pub use xitca_router::{params::Params, MatchError};
 
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap, error};
 
 use xitca_service::{
     object::{BoxedServiceObject, BoxedSyncServiceObject},
@@ -26,7 +26,6 @@ pub struct Router<Obj> {
 }
 
 /// Error type of Router service.
-#[derive(Debug)]
 pub enum RouterError<E> {
     /// failed to match on a routed service.
     Match(MatchError),
@@ -35,6 +34,34 @@ pub enum RouterError<E> {
     /// error produced by routed service.
     Service(E),
 }
+
+impl<E> fmt::Debug for RouterError<E>
+where
+    E: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::Match(ref e) => fmt::Debug::fmt(e, f),
+            Self::NotAllowed(ref e) => fmt::Debug::fmt(e, f),
+            Self::Service(ref e) => fmt::Debug::fmt(e, f),
+        }
+    }
+}
+
+impl<E> fmt::Display for RouterError<E>
+where
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::Match(ref e) => fmt::Display::fmt(e, f),
+            Self::NotAllowed(ref e) => fmt::Display::fmt(e, f),
+            Self::Service(ref e) => fmt::Display::fmt(e, f),
+        }
+    }
+}
+
+impl<E> error::Error for RouterError<E> where E: error::Error {}
 
 impl<Obj> Default for Router<Obj> {
     fn default() -> Self {

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -3,7 +3,7 @@
 pub use xitca_http::{
     error::BodyError,
     util::service::{
-        route::{MethodNotAllowed, RouteError},
+        route::MethodNotAllowed,
         router::{MatchError, RouterError},
     },
 };


### PR DESCRIPTION
remove `xitca_http::util::service::route::RouteError` and move it's variant into `xitca_http::util::service::router::RouterError`.
This change enables `Router` to accept `fn_service` and `get(fn_service)` at the same time without special error conversion.