### PR TITLE
rework xitca_web error type v2.

### DIFF
--- a/http/src/h1/proto/encode.rs
+++ b/http/src/h1/proto/encode.rs
@@ -226,7 +226,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        body::{BoxStream, Once},
+        body::{BoxBody, Once},
         bytes::Bytes,
         date::DateTimeService,
         http::{HeaderValue, Response},
@@ -241,7 +241,7 @@ mod test {
                 let date = DateTimeService::new();
                 let mut ctx = Context::<_, 64>::new(date.get());
 
-                let mut res = Response::new(BoxStream::new(Once::new(Bytes::new())));
+                let mut res = Response::new(BoxBody::new(Once::new(Bytes::new())));
 
                 res.headers_mut()
                     .insert(CONNECTION, HeaderValue::from_static("keep-alive"));

--- a/test/tests/h1.rs
+++ b/test/tests/h1.rs
@@ -7,7 +7,7 @@ use std::{
 
 use xitca_client::Client;
 use xitca_http::{
-    body::{BoxStream, ResponseBody},
+    body::{BoxBody, ResponseBody},
     bytes::{Bytes, BytesMut},
     h1,
     http::{
@@ -228,7 +228,7 @@ async fn handle(req: Request<RequestExt<h1::RequestBody>>) -> Result<Response<Re
             let ty = req.headers().get(header::CONTENT_TYPE).unwrap().clone();
 
             let body = req.into_body();
-            let mut res = Response::new(ResponseBody::stream(BoxStream::new(body)));
+            let mut res = Response::new(ResponseBody::stream(BoxBody::new(body)));
 
             res.headers_mut().insert(header::CONTENT_LENGTH, length);
             res.headers_mut().insert(header::CONTENT_TYPE, ty);

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -27,6 +27,8 @@ json = ["serde", "serde_json"]
 # urlencoded type extractor
 urlencoded = ["serde", "serde_urlencoded" ]
 
+serde = ["dep:serde"]
+
 # (de)compression middlewares
 compress-br = ["http-encoding/br"]
 compress-gz = ["http-encoding/gz"]

--- a/web/src/body.rs
+++ b/web/src/body.rs
@@ -4,19 +4,19 @@ use std::error;
 
 use futures_core::stream::Stream;
 
-pub use xitca_http::body::{none_body_hint, BoxStream, RequestBody, ResponseBody, NONE_BODY_HINT};
+pub use xitca_http::body::{none_body_hint, BoxBody, RequestBody, ResponseBody, NONE_BODY_HINT};
 
 /// an extended trait for [Stream] that specify additional type info of the [Stream::Item] type.
 pub trait BodyStream: Stream<Item = Result<Self::Chunk, Self::Error>> {
     type Chunk: AsRef<[u8]> + 'static;
-    type Error: error::Error + 'static;
+    type Error: error::Error + Send + Sync + 'static;
 }
 
 impl<S, T, E> BodyStream for S
 where
     S: Stream<Item = Result<T, E>>,
     T: AsRef<[u8]> + 'static,
-    E: error::Error + 'static,
+    E: error::Error + Send + Sync + 'static,
 {
     type Chunk = T;
     type Error = E;

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -1,5 +1,13 @@
 //! web error types.
 
+use core::{
+    convert::Infallible,
+    fmt,
+    ops::{Deref, DerefMut},
+};
+
+use std::error;
+
 pub use xitca_http::{
     error::BodyError,
     util::service::{
@@ -7,3 +15,115 @@ pub use xitca_http::{
         router::{MatchError, RouterError},
     },
 };
+
+use crate::{
+    context::WebContext,
+    dev::service::{object::ServiceObject, Service},
+    http::WebResponse,
+};
+
+use self::service_impl::ErrorService;
+
+type BoxErrService<C> = Box<dyn for<'r> ErrorService<WebContext<'r, C>>>;
+
+#[derive(Debug)]
+pub struct Error<C>(BoxErrService<C>);
+
+impl<C> fmt::Display for Error<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl<C> Deref for Error<C> {
+    type Target = BoxErrService<C>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<C> DerefMut for Error<C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<C, S> From<S> for Error<C>
+where
+    S: for<'r> Service<WebContext<'r, C>, Response = WebResponse, Error = Infallible>
+        + error::Error
+        + Send
+        + Sync
+        + 'static,
+{
+    fn from(s: S) -> Self {
+        Self(Box::new(s))
+    }
+}
+
+impl<'r, C> Service<WebContext<'r, C>> for Error<C> {
+    type Response = WebResponse;
+    type Error = Infallible;
+
+    async fn call(&self, ctx: WebContext<'r, C>) -> Result<Self::Response, Self::Error> {
+        ServiceObject::call(&***self, ctx).await
+    }
+}
+
+mod service_impl {
+    use super::*;
+
+    pub trait ErrorService<Req>:
+        ServiceObject<Req, Response = WebResponse, Error = Infallible> + error::Error + Send + Sync
+    {
+    }
+
+    impl<S, Req> ErrorService<Req> for S where
+        S: ServiceObject<Req, Response = WebResponse, Error = Infallible> + error::Error + Send + Sync
+    {
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::fmt;
+
+    use xitca_unsafe_collection::futures::NowOrPanic;
+
+    use crate::body::ResponseBody;
+
+    use super::*;
+
+    #[test]
+    fn cast() {
+        #[derive(Debug)]
+        struct Foo;
+
+        impl fmt::Display for Foo {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("Foo")
+            }
+        }
+
+        impl error::Error for Foo {}
+
+        impl<'r, C> Service<WebContext<'r, C>> for Foo {
+            type Response = WebResponse;
+            type Error = Infallible;
+
+            async fn call(&self, _: WebContext<'r, C>) -> Result<Self::Response, Self::Error> {
+                Ok(WebResponse::new(ResponseBody::None))
+            }
+        }
+
+        let foo = Error::<()>::from(Foo);
+
+        println!("{foo:?}");
+        println!("{foo}");
+
+        let mut ctx = WebContext::new_test(());
+        let res = Service::call(&foo, ctx.as_web_ctx()).now_or_panic().unwrap();
+        assert_eq!(res.status().as_u16(), 200);
+    }
+}

--- a/web/src/handler/error.rs
+++ b/web/src/handler/error.rs
@@ -1,132 +1,69 @@
-use core::{convert::Infallible, fmt, str::Utf8Error};
+use core::{convert::Infallible, fmt};
 
 use std::error;
-
-#[cfg(feature = "multipart")]
-use http_multipart::MultipartError;
-#[cfg(feature = "json")]
-use serde_json::Error as JsonError;
 
 use crate::{
     bytes::Bytes,
     context::WebContext,
-    error::BodyError,
+    dev::service::Service,
     http::{header::HeaderName, StatusCode, WebResponse},
 };
 
-use super::Responder;
-
 type BoxedError = Box<dyn error::Error + Send + Sync + 'static>;
+
+pub(crate) fn blank_bad_request<C, B>(req: WebContext<'_, C, B>) -> WebResponse {
+    let mut res = req.into_response(Bytes::new());
+    *res.status_mut() = StatusCode::BAD_REQUEST;
+    res
+}
 
 /// Collection of all default extract types's error.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum ExtractError<E = BodyError> {
-    /// Request body error.
-    Body(E),
-    /// Absent type of request's (Extensions)[crate::http::Extensions] type map.
-    ExtensionNotFound,
+pub enum ExtractError {
+    // unnamed internal error type.
+    Internal,
     /// Absent header value.
     HeaderNotFound(HeaderName),
-    /// Error of parsing bytes to Rust types.
-    Parse(ParseError),
     /// fallback boxed error type.
     Boxed(BoxedError),
 }
 
-impl<E: fmt::Display> fmt::Display for ExtractError<E> {
+impl fmt::Display for ExtractError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Self::Body(ref e) => fmt::Display::fmt(e, f),
-            Self::ExtensionNotFound => f.write_str("Extension can not be found"),
+            Self::Internal => f.write_str("Internal error"),
             Self::HeaderNotFound(ref name) => write!(f, "HeaderName: {name} not found."),
-            Self::Parse(ref e) => fmt::Display::fmt(e, f),
             Self::Boxed(ref e) => fmt::Display::fmt(e, f),
         }
     }
 }
 
-impl<E> error::Error for ExtractError<E> where E: fmt::Debug + fmt::Display {}
+impl error::Error for ExtractError {}
 
-impl<E> From<Infallible> for ExtractError<E> {
+impl From<Infallible> for ExtractError {
     fn from(e: Infallible) -> Self {
         match e {}
     }
 }
 
-impl<'r, C, B, E> Responder<WebContext<'r, C, B>> for ExtractError<E> {
-    type Output = WebResponse;
+impl<'r, C, B> Service<WebContext<'r, C, B>> for ExtractError {
+    type Response = WebResponse;
+    type Error = Infallible;
 
-    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Self::Output {
+    async fn call(&self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         let mut res = ctx.into_response(Bytes::new());
         *res.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-        res
+        Ok(res)
     }
 }
 
-#[derive(Debug)]
-pub struct ParseError(_ParseError);
+#[cfg(feature = "serde")]
+impl<'r, C, B> Service<WebContext<'r, C, B>> for serde::de::value::Error {
+    type Response = WebResponse;
+    type Error = Infallible;
 
-impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            _ParseError::String(ref e) => fmt::Display::fmt(e, f),
-            #[cfg(feature = "params")]
-            _ParseError::Params(ref e) => fmt::Display::fmt(e, f),
-            #[cfg(feature = "json")]
-            _ParseError::JsonString(ref e) => fmt::Display::fmt(e, f),
-            #[cfg(feature = "urlencoded")]
-            _ParseError::UrlEncoded(ref e) => fmt::Display::fmt(e, f),
-            #[cfg(feature = "multipart")]
-            _ParseError::Multipart(ref e) => fmt::Display::fmt(e, f),
-        }
-    }
-}
-
-// a private type to hide 3rd part crates error types from ExtractError interface.
-#[derive(Debug)]
-pub(super) enum _ParseError {
-    String(Utf8Error),
-    #[cfg(feature = "params")]
-    Params(serde::de::value::Error),
-    #[cfg(feature = "json")]
-    JsonString(JsonError),
-    #[cfg(feature = "urlencoded")]
-    UrlEncoded(serde_urlencoded::de::Error),
-    #[cfg(feature = "multipart")]
-    Multipart(MultipartError<Infallible>),
-}
-
-impl<E> From<_ParseError> for ExtractError<E> {
-    fn from(e: _ParseError) -> Self {
-        Self::Parse(ParseError(e))
-    }
-}
-
-#[cfg(feature = "json")]
-impl<E> From<JsonError> for ExtractError<E> {
-    fn from(e: JsonError) -> Self {
-        Self::from(_ParseError::JsonString(e))
-    }
-}
-
-#[cfg(feature = "multipart")]
-impl<E> From<MultipartError<E>> for ExtractError<E> {
-    fn from(e: MultipartError<E>) -> Self {
-        // TODO: sort this out?
-        match e {
-            MultipartError::NoPostMethod => Self::from(_ParseError::Multipart(MultipartError::NoPostMethod)),
-            MultipartError::NoContentDisposition => {
-                Self::from(_ParseError::Multipart(MultipartError::NoContentDisposition))
-            }
-            MultipartError::NoContentType => Self::from(_ParseError::Multipart(MultipartError::NoContentType)),
-            MultipartError::ParseContentType => Self::from(_ParseError::Multipart(MultipartError::ParseContentType)),
-            MultipartError::Boundary => Self::from(_ParseError::Multipart(MultipartError::Boundary)),
-            MultipartError::Nested => Self::from(_ParseError::Multipart(MultipartError::Nested)),
-            MultipartError::UnexpectedEof => Self::from(_ParseError::Multipart(MultipartError::UnexpectedEof)),
-            MultipartError::BufferOverflow => Self::from(_ParseError::Multipart(MultipartError::BufferOverflow)),
-            MultipartError::Header(e) => Self::from(_ParseError::Multipart(MultipartError::Header(e))),
-            MultipartError::Payload(e) => Self::Body(e),
-        }
+    async fn call(&self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+        Ok(blank_bad_request(ctx))
     }
 }

--- a/web/src/handler/types/body.rs
+++ b/web/src/handler/types/body.rs
@@ -1,10 +1,6 @@
 //! type extractor for request body stream.
 
-use crate::{
-    body::BodyStream,
-    context::WebContext,
-    handler::{error::ExtractError, FromRequest},
-};
+use crate::{body::BodyStream, context::WebContext, error::Error, handler::FromRequest};
 
 pub struct Body<B>(pub B);
 
@@ -13,7 +9,7 @@ where
     B: BodyStream + Default,
 {
     type Type<'b> = Body<B>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/extension.rs
+++ b/web/src/handler/types/extension.rs
@@ -2,21 +2,20 @@
 
 use core::{fmt, ops::Deref};
 
+use std::{convert::Infallible, error};
+
 use crate::{
     body::BodyStream,
     context::WebContext,
-    handler::{error::ExtractError, FromRequest},
-    http::Extensions,
+    dev::service::Service,
+    error::Error,
+    handler::{error::blank_bad_request, FromRequest},
+    http::{Extensions, WebResponse},
 };
 
 /// Extract immutable reference of element stored inside [Extensions]
+#[derive(Debug)]
 pub struct ExtensionRef<'a, T>(pub &'a T);
-
-impl<T: fmt::Debug> fmt::Debug for ExtensionRef<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ExtensionRef({:?})", self.0)
-    }
-}
 
 impl<T> Deref for ExtensionRef<'_, T> {
     type Target = T;
@@ -32,16 +31,15 @@ where
     B: BodyStream,
 {
     type Type<'b> = ExtensionRef<'b, T>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let ext = ctx
-            .req()
+        ctx.req()
             .extensions()
             .get::<T>()
-            .ok_or(ExtractError::ExtensionNotFound)?;
-        Ok(ExtensionRef(ext))
+            .map(ExtensionRef)
+            .ok_or_else(|| ExtensionNotFound.into())
     }
 }
 
@@ -68,17 +66,15 @@ where
     B: BodyStream,
 {
     type Type<'b> = ExtensionOwn<T>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
-        let ext = ctx
-            .req()
+        ctx.req()
             .extensions()
             .get::<T>()
-            .ok_or(ExtractError::ExtensionNotFound)?
-            .clone();
-        Ok(ExtensionOwn(ext))
+            .map(|ext| ExtensionOwn(ext.clone()))
+            .ok_or_else(|| ExtensionNotFound.into())
     }
 }
 
@@ -98,10 +94,31 @@ where
     B: BodyStream,
 {
     type Type<'b> = ExtensionsRef<'b>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         Ok(ExtensionsRef(ctx.req().extensions()))
+    }
+}
+
+/// Absent type of request's (Extensions)[crate::http::Extensions] type map.
+#[derive(Debug)]
+pub struct ExtensionNotFound;
+
+impl fmt::Display for ExtensionNotFound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Extension data type can not be found")
+    }
+}
+
+impl error::Error for ExtensionNotFound {}
+
+impl<'r, C, B> Service<WebContext<'r, C, B>> for ExtensionNotFound {
+    type Response = WebResponse;
+    type Error = Infallible;
+
+    async fn call(&self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+        Ok(blank_bad_request(ctx))
     }
 }

--- a/web/src/handler/types/header.rs
+++ b/web/src/handler/types/header.rs
@@ -5,6 +5,7 @@ use core::{fmt, ops::Deref};
 use crate::{
     body::BodyStream,
     context::WebContext,
+    error::Error,
     handler::{error::ExtractError, FromRequest},
     http::header::{self, HeaderValue},
 };
@@ -64,7 +65,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = HeaderRef<'b, HEADER_NAME>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
@@ -72,7 +73,7 @@ where
             .headers()
             .get(&map_to_header_name::<HEADER_NAME>())
             .map(HeaderRef)
-            .ok_or_else(|| ExtractError::HeaderNotFound(map_to_header_name::<HEADER_NAME>()))
+            .ok_or_else(|| Error::from(ExtractError::HeaderNotFound(map_to_header_name::<HEADER_NAME>())))
     }
 }
 

--- a/web/src/handler/types/params.rs
+++ b/web/src/handler/types/params.rs
@@ -7,14 +7,7 @@ use serde::{forward_to_deserialize_any, Deserialize};
 
 use xitca_http::util::service::router;
 
-use crate::{
-    body::BodyStream,
-    context::WebContext,
-    handler::{
-        error::{ExtractError, _ParseError},
-        FromRequest,
-    },
-};
+use crate::{body::BodyStream, context::WebContext, error::Error, handler::FromRequest};
 
 #[derive(Debug)]
 pub struct Params<T>(pub T);
@@ -25,12 +18,12 @@ where
     T: for<'de> Deserialize<'de>,
 {
     type Type<'b> = Params<T>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let params = ctx.req().body().params();
-        let params = T::deserialize(Params2::new(params)).map_err(_ParseError::Params)?;
+        let params = T::deserialize(Params2::new(params))?;
         Ok(Params(params))
     }
 }
@@ -51,7 +44,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = ParamsRef<'b>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/path.rs
+++ b/web/src/handler/types/path.rs
@@ -2,11 +2,7 @@
 
 use core::ops::Deref;
 
-use crate::{
-    body::BodyStream,
-    context::WebContext,
-    handler::{error::ExtractError, FromRequest},
-};
+use crate::{body::BodyStream, context::WebContext, error::Error, handler::FromRequest};
 
 #[derive(Debug)]
 pub struct PathRef<'a>(pub &'a str);
@@ -24,7 +20,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = PathRef<'b>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
@@ -48,7 +44,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = PathOwn;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/request.rs
+++ b/web/src/handler/types/request.rs
@@ -5,7 +5,8 @@ use core::ops::Deref;
 use crate::{
     body::BodyStream,
     context::WebContext,
-    handler::{error::ExtractError, FromRequest},
+    error::Error,
+    handler::FromRequest,
     http::{Request, RequestExt},
 };
 
@@ -25,7 +26,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = RequestRef<'b>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/state.rs
+++ b/web/src/handler/types/state.rs
@@ -2,11 +2,7 @@
 
 use core::{borrow::Borrow, fmt, ops::Deref};
 
-use crate::{
-    body::BodyStream,
-    context::WebContext,
-    handler::{error::ExtractError, FromRequest},
-};
+use crate::{body::BodyStream, context::WebContext, error::Error, handler::FromRequest};
 
 /// App state extractor.
 /// S type must be the same with the type passed to App::with_xxx_state(S).
@@ -39,7 +35,7 @@ where
     T: 'static,
 {
     type Type<'b> = StateRef<'b, T>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
@@ -78,7 +74,7 @@ where
     T: Clone,
 {
     type Type<'b> = StateOwn<T>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/handler/types/string.rs
+++ b/web/src/handler/types/string.rs
@@ -1,10 +1,12 @@
+use std::convert::Infallible;
+
 use crate::{
     body::BodyStream,
     context::WebContext,
-    handler::{
-        error::{ExtractError, _ParseError},
-        FromRequest,
-    },
+    dev::service::Service,
+    error::Error,
+    handler::{error::blank_bad_request, FromRequest},
+    http::WebResponse,
 };
 
 impl<'a, 'r, C, B> FromRequest<'a, WebContext<'r, C, B>> for String
@@ -12,11 +14,20 @@ where
     B: BodyStream + Default,
 {
     type Type<'b> = String;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
         let vec = Vec::from_request(ctx).await?;
-        Ok(String::from_utf8(vec).map_err(|e| _ParseError::String(e.utf8_error()))?)
+        String::from_utf8(vec).map_err(Into::into)
+    }
+}
+
+impl<'r, C, B> Service<WebContext<'r, C, B>> for std::string::FromUtf8Error {
+    type Response = WebResponse;
+    type Error = Infallible;
+
+    async fn call(&self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+        Ok(blank_bad_request(ctx))
     }
 }

--- a/web/src/handler/types/uri.rs
+++ b/web/src/handler/types/uri.rs
@@ -1,11 +1,6 @@
 use std::ops::Deref;
 
-use crate::{
-    body::BodyStream,
-    context::WebContext,
-    handler::{error::ExtractError, FromRequest},
-    http::Uri,
-};
+use crate::{body::BodyStream, context::WebContext, error::Error, handler::FromRequest, http::Uri};
 
 #[derive(Debug)]
 pub struct UriRef<'a>(pub &'a Uri);
@@ -23,7 +18,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = UriRef<'b>;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {
@@ -47,7 +42,7 @@ where
     B: BodyStream,
 {
     type Type<'b> = UriOwn;
-    type Error = ExtractError<B::Error>;
+    type Error = Error<C>;
 
     #[inline]
     async fn from_request(ctx: &'a WebContext<'r, C, B>) -> Result<Self, Self::Error> {

--- a/web/src/middleware/decompress.rs
+++ b/web/src/middleware/decompress.rs
@@ -6,7 +6,6 @@ use crate::{
     body::BodyStream,
     context::WebContext,
     dev::service::{pipeline::PipelineE, ready::ReadyService, Service},
-    handler::Responder,
     http::{const_header_value::TEXT_UTF8, header::CONTENT_TYPE, Request, StatusCode, WebResponse},
 };
 
@@ -67,14 +66,15 @@ where
     }
 }
 
-impl<'r, C, B> Responder<WebContext<'r, C, B>> for EncodingError {
-    type Output = WebResponse;
+impl<'r, C, B> Service<WebContext<'r, C, B>> for EncodingError {
+    type Response = WebResponse;
+    type Error = Infallible;
 
-    async fn respond_to(self, req: WebContext<'r, C, B>) -> Self::Output {
+    async fn call(&self, req: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         let mut res = req.into_response(format!("{self}"));
         res.headers_mut().insert(CONTENT_TYPE, TEXT_UTF8);
         *res.status_mut() = StatusCode::UNSUPPORTED_MEDIA_TYPE;
-        res
+        Ok(res)
     }
 }
 


### PR DESCRIPTION
rename `xitca_http::body::BoxStream` to `BoxBody`.
add `xitca_web::error::Error` type for type erase error handling. all extractors now return Error<C>.
replace `Responder` trait with `Service` trait for error generation.