### PR TITLE
rework middleware.

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -45,12 +45,120 @@ pub fn state_impl(item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn service_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    middleware_impl(_attr, item)
+pub fn middleware_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemImpl);
+
+    // Collect type path from impl.
+    let service_ty = match input.self_ty.as_ref() {
+        Type::Path(path) => path,
+        _ => panic!("impl macro must be used on a TypePath"),
+    };
+
+    // collect generics.
+    let generic_ty = &input.generics.params;
+    let where_clause = &input.generics.where_clause;
+
+    // find methods from impl.
+    let new_service_impl =
+        find_async_method(&input.items, "new_service").expect("new_service method can not be located");
+
+    let new_service_generic_err_ty = new_service_impl
+        .sig
+        .generics
+        .params
+        .first()
+        .expect("new_service must annotate generic E type");
+
+    let new_service_rt_err_ty =
+        find_new_service_rt_err_ty(new_service_impl).expect("new_service must return Result<Self, E> type.");
+
+    // collect ServiceFactory type
+    let mut inputs = new_service_impl.sig.inputs.iter();
+
+    let (factory_ident, factory_ty) = match inputs.next().unwrap() {
+        FnArg::Receiver(_) => panic!("new_service method does not accept Self as receiver"),
+        FnArg::Typed(ty) => match (ty.pat.as_ref(), ty.ty.as_ref()) {
+            (Pat::Wild(_), Type::Reference(ty_ref)) if ty_ref.mutability.is_none() => {
+                (default_pat_ident("_factory"), &ty_ref.elem)
+            }
+            (Pat::Ident(ident), Type::Reference(ty_ref)) if ty_ref.mutability.is_none() => {
+                (ident.to_owned(), &ty_ref.elem)
+            }
+            _ => panic!("new_service must receive ServiceFactory type as immutable reference"),
+        },
+    };
+    let (arg_ident, arg_ty) = match inputs.next().unwrap() {
+        FnArg::Receiver(_) => panic!("new_service method must not receive Self as receiver"),
+        FnArg::Typed(ty) => match ty.pat.as_ref() {
+            Pat::Wild(_) => (default_pat_ident("_service"), &*ty.ty),
+            Pat::Ident(ident) => (ident.to_owned(), &*ty.ty),
+            _ => panic!("new_service method must use <arg: Arg> as second function argument"),
+        },
+    };
+
+    let factory_stmts = &new_service_impl.block.stmts;
+
+    let ready_impl = ReadyImpl::try_from_items(&input.items);
+
+    let CallImpl {
+        req_ident,
+        req_ty,
+        res_ty,
+        err_ty,
+        call_stmts,
+    } = CallImpl::from_items(&input.items);
+
+    let base = quote! {
+        impl<#generic_ty, #new_service_generic_err_ty> ::xitca_service::Service<#arg_ty> for #factory_ty
+        #where_clause
+        {
+            type Response = #service_ty;
+            type Error = #new_service_rt_err_ty;
+
+            async fn call(&self, #arg_ident: #arg_ty) -> Result<Self::Response, Self::Error> {
+                let #factory_ident = &self;
+                #(#factory_stmts)*
+            }
+        }
+
+        impl<#generic_ty> ::xitca_service::Service<#req_ty> for #service_ty
+        #where_clause
+        {
+            type Response = #res_ty;
+            type Error = #err_ty;
+
+            #[inline]
+            async fn call(&self, #req_ident: #req_ty) -> Result<Self::Response, Self::Error> {
+                #(#call_stmts)*
+            }
+        }
+    };
+
+    match ready_impl {
+        Some(ReadyImpl {
+            ready_stmts,
+            ready_ret_ty: ready_res_ty,
+        }) => quote! {
+            #base
+
+            impl<#generic_ty> ::xitca_service::ready::ReadyService for #service_ty
+            #where_clause
+            {
+                type Ready = #ready_res_ty;
+
+                #[inline]
+                async fn ready(&self) -> Self::Ready {
+                    #(#ready_stmts)*
+                }
+            }
+        }
+        .into(),
+        None => base.into(),
+    }
 }
 
 #[proc_macro_attribute]
-pub fn middleware_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn service_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemImpl);
 
     // Collect type path from impl.
@@ -160,6 +268,29 @@ fn find_async_method<'a>(items: &'a [ImplItem], ident_str: &str) -> Option<&'a I
         }
         _ => None,
     })
+}
+
+fn find_new_service_rt_err_ty(func: &ImplItemFn) -> Option<&Type> {
+    let ReturnType::Type(_, ref new_service_rt_ty) = func.sig.output else {
+        return None;
+    };
+    let Type::Path(ref path) = **new_service_rt_ty else {
+        return None;
+    };
+    let path = path.path.segments.first()?;
+
+    if path.ident.to_string() != "Result" {
+        return None;
+    }
+
+    let PathArguments::AngleBracketed(ref bracket) = path.arguments else {
+        return None;
+    };
+
+    match bracket.args.last().unwrap() {
+        GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    }
 }
 
 struct CallImpl<'a> {

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -279,7 +279,7 @@ fn find_new_service_rt_err_ty(func: &ImplItemFn) -> Option<&Type> {
     };
     let path = path.path.segments.first()?;
 
-    if path.ident.to_string() != "Result" {
+    if path.ident != "Result" {
         return None;
     }
 
@@ -356,7 +356,7 @@ fn extract_res_ty(ret: &ReturnType) -> (&Type, &Type) {
     if let ReturnType::Type(_, ty) = ret {
         if let Type::Path(path) = ty.as_ref() {
             let seg = path.path.segments.first().unwrap();
-            if seg.ident.to_string().as_str() == "Result" {
+            if seg.ident == "Result" {
                 if let PathArguments::AngleBracketed(ref arg) = seg.arguments {
                     if let (Some(GenericArgument::Type(ok_ty)), Some(GenericArgument::Type(err_ty))) =
                         (arg.args.first(), arg.args.last())

--- a/examples/multi-http-services/src/main.rs
+++ b/examples/multi-http-services/src/main.rs
@@ -46,7 +46,9 @@ fn main() -> io::Result<()> {
         .bind(
             "http/2",
             "127.0.0.1:8081",
-            fn_service(handler_h2).enclosed(HttpServiceBuilder::h2().openssl(acceptor).with_logger()),
+            fn_service(handler_h2)
+                .enclosed(HttpServiceBuilder::h2().openssl(acceptor))
+                .enclosed(Logger::default()),
         )?
         // bind to a http/3 service.
         // *. note the service name must be unique.

--- a/http/src/h2/builder.rs
+++ b/http/src/h2/builder.rs
@@ -1,19 +1,26 @@
+use core::fmt;
+
 use xitca_service::Service;
 
 use crate::builder::{marker, HttpServiceBuilder};
 
 use super::service::H2Service;
 
-impl<St, S, FA, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIMIT: usize> Service<S>
-    for HttpServiceBuilder<marker::Http2, St, FA, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
+type Error = Box<dyn fmt::Debug>;
+
+impl<St, FA, S, E, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIMIT: usize>
+    Service<Result<S, E>> for HttpServiceBuilder<marker::Http2, St, FA, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
 where
     FA: Service,
+    FA::Error: fmt::Debug + 'static,
+    E: fmt::Debug + 'static,
 {
     type Response = H2Service<St, S, FA::Response, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>;
-    type Error = FA::Error;
+    type Error = Error;
 
-    async fn call(&self, service: S) -> Result<Self::Response, Self::Error> {
-        let tls_acceptor = self.tls_factory.call(()).await?;
+    async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
+        let service = res.map_err(|e| Box::new(e) as Error)?;
+        let tls_acceptor = self.tls_factory.call(()).await.map_err(|e| Box::new(e) as Error)?;
         Ok(H2Service::new(self.config, service, tls_acceptor))
     }
 }

--- a/http/src/h3/builder.rs
+++ b/http/src/h3/builder.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use xitca_service::Service;
 
 use super::service::H3Service;
@@ -21,11 +19,11 @@ impl H3ServiceBuilder {
     }
 }
 
-impl<S> Service<S> for H3ServiceBuilder {
+impl<S, E> Service<Result<S, E>> for H3ServiceBuilder {
     type Response = H3Service<S>;
-    type Error = Infallible;
+    type Error = E;
 
-    async fn call(&self, service: S) -> Result<Self::Response, Self::Error> {
-        Ok(H3Service::new(service))
+    async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
+        res.map(H3Service::new)
     }
 }

--- a/http/src/util/middleware/logger.rs
+++ b/http/src/util/middleware/logger.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::Infallible,
     fmt::Debug,
     future::Future,
     pin::Pin,
@@ -32,13 +31,15 @@ impl Logger {
     }
 }
 
-impl<S> Service<S> for Logger {
+impl<S, E> Service<Result<S, E>> for Logger {
     type Response = LoggerService<S>;
-    type Error = Infallible;
+    type Error = E;
 
-    async fn call(&self, service: S) -> Result<Self::Response, Self::Error> {
-        let span = self.span.clone();
-        Ok(LoggerService { service, span })
+    async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
+        res.map(|service| LoggerService {
+            service,
+            span: self.span.clone(),
+        })
     }
 }
 

--- a/http/src/util/middleware/socket_config.rs
+++ b/http/src/util/middleware/socket_config.rs
@@ -1,4 +1,4 @@
-use core::{convert::Infallible, time::Duration};
+use core::time::Duration;
 
 use std::{io, net::SocketAddr};
 
@@ -66,13 +66,15 @@ impl SocketConfig {
     }
 }
 
-impl<S> Service<S> for SocketConfig {
+impl<S, E> Service<Result<S, E>> for SocketConfig {
     type Response = SocketConfigService<S>;
-    type Error = Infallible;
+    type Error = E;
 
-    async fn call(&self, service: S) -> Result<Self::Response, Self::Error> {
-        let config = self.clone();
-        Ok(SocketConfigService { config, service })
+    async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
+        res.map(|service| SocketConfigService {
+            config: self.clone(),
+            service,
+        })
     }
 }
 

--- a/service/src/service/function.rs
+++ b/service/src/service/function.rs
@@ -43,8 +43,8 @@ where
 ///
 /// [ServiceExt::enclosed]: super::ServiceExt::enclosed
 /// [ServiceExt::enclosed_fn]: super::ServiceExt::enclosed_fn
-pub fn fn_build_nop<Arg>() -> FnService<impl Fn(Arg) -> Ready<Result<Arg, Infallible>> + Clone> {
-    fn_build(|arg| ready(Ok(arg)))
+pub fn fn_build_nop<S, E>() -> FnService<impl Fn(Result<S, E>) -> Ready<Result<S, E>> + Clone> {
+    fn_build(ready)
 }
 
 /// Shortcut for transform a given Fn into type impl [Service] trait.

--- a/test/tests/macro.rs
+++ b/test/tests/macro.rs
@@ -33,8 +33,8 @@ impl<S> TestMiddlewareService<S>
 where
     S: ReadyService + Service<String, Error = Box<dyn std::error::Error>, Response = usize>,
 {
-    async fn new_service(_m: &TestMiddleware, service: S) -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(TestMiddlewareService(service))
+    async fn new_service<E>(_m: &TestMiddleware, res: Result<S, E>) -> Result<Self, E> {
+        res.map(TestMiddlewareService)
     }
 
     async fn ready(&self) -> S::Ready {

--- a/web/src/middleware/eraser.rs
+++ b/web/src/middleware/eraser.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, error, marker::PhantomData};
+use std::{error, marker::PhantomData};
 
 use xitca_http::ResponseBody;
 
@@ -56,12 +56,12 @@ impl TypeEraser<EraseErr> {
     }
 }
 
-impl<M, S> Service<S> for TypeEraser<M> {
+impl<M, S, E> Service<Result<S, E>> for TypeEraser<M> {
     type Response = EraserService<M, S>;
-    type Error = Infallible;
+    type Error = E;
 
-    async fn call(&self, service: S) -> Result<Self::Response, Self::Error> {
-        Ok(EraserService {
+    async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
+        res.map(|service| EraserService {
             service,
             _erase: PhantomData,
         })

--- a/web/src/middleware/limit.rs
+++ b/web/src/middleware/limit.rs
@@ -42,12 +42,12 @@ impl Limit {
     }
 }
 
-impl<S> Service<S> for Limit {
+impl<S, E> Service<Result<S, E>> for Limit {
     type Response = LimitService<S>;
-    type Error = Infallible;
+    type Error = E;
 
-    async fn call(&self, service: S) -> Result<Self::Response, Self::Error> {
-        Ok(LimitService { service, limit: *self })
+    async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
+        res.map(|service| LimitService { service, limit: *self })
     }
 }
 


### PR DESCRIPTION
`ServiceExt::enclosed` now accept a type impl `Service<Result<S, E>>`. This enables middleware handling inner service builder's error type inside it's `Service::call` method. 

Before:
```rust
impl<S> Service<S> for Mw {
    async fn call(&self, service: S) -> Result<Self::Response, Self::Error> {
        // know nothing about the error path of producing S 
    }
}

Router::new()
    .insert("/", fn_service(...))
    .insert("/", fn_service(...).enclosed(Mw))  // this line can easily fail due to Mw don't know the proper error type.
```

Now:
```rust
impl<Result<S, E>> Service<Result<S, E>> for Mw {
    async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
        // mw is able to handle inner service builder error with E type.
    }
}

Router::new()
    .insert("/", fn_service(...))
    .insert("/", fn_service(...).enclosed(Mw))  // this line would work by properly mapping the E type in above trait impl.
```

