### PR TITLE
rework handler_service's error handling.

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "cloudflare-worker",
     "compression",
+    "error-handle",
     "file",
     "grpc",
     "hello-world",

--- a/examples/error-handle/Cargo.toml
+++ b/examples/error-handle/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "error-handle"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+xitca-web = "0.1"

--- a/examples/error-handle/src/main.rs
+++ b/examples/error-handle/src/main.rs
@@ -1,0 +1,95 @@
+//! example of error handling in xitca-web.
+//! code must be compiled on nightly.
+
+use std::{convert::Infallible, error, fmt};
+
+use xitca_web::{
+    bytes::Bytes,
+    dev::service::Service,
+    error::Error,
+    handler::handler_service,
+    http::{StatusCode, WebResponse},
+    route::get,
+    App, WebContext,
+};
+
+fn main() -> std::io::Result<()> {
+    App::new()
+        .at("/", get(handler_service(index)))
+        .enclosed_fn(error_handler)
+        .serve()
+        .bind("127.0.0.1:8080")?
+        .run()
+        .wait()
+}
+
+// a route always return an error type that would produce 400 bad-request http response.
+// see below MyError implements for more explanation
+async fn index() -> Result<&'static str, MyError> {
+    Err(MyError::Index)
+}
+
+// an enum error type. must implement following traits:
+// std::fmt::{Debug, Display} for formatting
+// std::error::Error for backtrace and type casting
+// xitca_web::dev::service::Service for http response generation.
+#[derive(Debug)]
+enum MyError {
+    Index,
+}
+
+impl fmt::Display for MyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Index => f.write_str("error from /"),
+        }
+    }
+}
+
+impl error::Error for MyError {}
+
+// Error<C> is the main error type xitca-web uses and at some point MyError would
+// need to be converted to it.
+impl<C> From<MyError> for Error<C> {
+    fn from(e: MyError) -> Self {
+        Error::from_service(e)
+    }
+}
+
+// response generator of MyError. in this case we generate blank bad request error.
+impl<'r, C> Service<WebContext<'r, C>> for MyError {
+    type Response = WebResponse;
+    type Error = Infallible;
+
+    async fn call(&self, ctx: WebContext<'r, C>) -> Result<Self::Response, Self::Error> {
+        let mut res = ctx.into_response(Bytes::new());
+        *res.status_mut() = StatusCode::BAD_REQUEST;
+        Ok(res)
+    }
+}
+
+// a middleware function used for intercept and interact with app handler outputs.
+async fn error_handler<S, C, B, Res>(s: &S, ctx: WebContext<'_, C, B>) -> Result<Res, Error<C>>
+where
+    S: for<'r> Service<WebContext<'r, C, B>, Response = Res, Error = Error<C>>,
+{
+    s.call(ctx).await.map_err(|e| {
+        // debug format error info.
+        println!("{e:?}");
+
+        // display format error info.
+        println!("{e}");
+
+        // utilize std::error::Error trait methods for backtrace and more advanced error info.
+        let _source = e.source();
+
+        // upcast trait and downcast to concrete type again.
+        // this offers the ability to regain typed error specific error handling.
+        // *. this is a runtime feature and not reinforced at compile time.
+        if let Some(e) = (&**e as &dyn error::Error).downcast_ref::<MyError>() {
+            println!("downcast error type: {e:?}")
+        }
+
+        e
+    })
+}

--- a/examples/error-handle/src/main.rs
+++ b/examples/error-handle/src/main.rs
@@ -1,5 +1,5 @@
 //! example of error handling in xitca-web.
-//! code must be compiled on nightly.
+//! code must be compiled with nightly Rust.
 
 use std::{convert::Infallible, error, fmt};
 
@@ -87,7 +87,9 @@ where
         // this offers the ability to regain typed error specific error handling.
         // *. this is a runtime feature and not reinforced at compile time.
         if let Some(e) = (&**e as &dyn error::Error).downcast_ref::<MyError>() {
-            println!("downcast error type: {e:?}")
+            match e {
+                MyError::Index => {}
+            }
         }
 
         e

--- a/examples/file/src/main.rs
+++ b/examples/file/src/main.rs
@@ -8,7 +8,7 @@ fn main() -> std::io::Result<()> {
     println!("open http://localhost:8080/index.html in browser to visit the site");
     App::new()
         /*
-            map "/" prefix uri to ""./static" file path. for example http request with uri of
+            map "/" prefix uri to "./static" file path. for example http request with uri of
             "/index.html" will be matched against "./static/index.html" file. then enclose the
             serve file service with compress middleware for file compression.
         */

--- a/examples/sync/src/main.rs
+++ b/examples/sync/src/main.rs
@@ -24,7 +24,10 @@ fn main() -> std::io::Result<()> {
 // generic C type is the type state of App.
 fn middleware_fn<E, C>(next: &mut Next<E>, ctx: WebContext<'_, C>) -> Result<WebResponse<()>, E> {
     // before calling the next service we can access and/or mutate the state of context.
-    let res = next.call(ctx); // call next service.
+
+    // call next service.
+    let res = next.call(ctx);
+
     // after the next service call return we can access and/or mutate the output.
     res
 }

--- a/web/src/handler/types/html.rs
+++ b/web/src/handler/types/html.rs
@@ -1,6 +1,6 @@
 //! response generator for Html
 
-use core::fmt;
+use core::{convert::Infallible, fmt};
 
 use xitca_http::body::ResponseBody;
 
@@ -21,16 +21,17 @@ where
     }
 }
 
-impl<'r, S, T> Responder<WebContext<'r, S>> for Html<T>
+impl<'r, C, T> Responder<WebContext<'r, C>> for Html<T>
 where
     T: Into<ResponseBody>,
 {
-    type Output = WebResponse;
+    type Response = WebResponse;
+    type Error = Infallible;
 
     #[inline]
-    async fn respond_to(self, ctx: WebContext<'r, S>) -> Self::Output {
+    async fn respond_to(self, ctx: WebContext<'r, C>) -> Result<Self::Response, Self::Error> {
         let mut res = ctx.into_response(self.0);
         res.headers_mut().insert(CONTENT_TYPE, TEXT_HTML_UTF8);
-        res
+        Ok(res)
     }
 }

--- a/web/src/handler/types/vec.rs
+++ b/web/src/handler/types/vec.rs
@@ -1,4 +1,4 @@
-use core::{future::poll_fn, pin::pin};
+use core::{convert::Infallible, future::poll_fn, pin::pin};
 
 use crate::{
     body::BodyStream,
@@ -34,9 +34,10 @@ where
 }
 
 impl<'r, C, B> Responder<WebContext<'r, C, B>> for Vec<u8> {
-    type Output = WebResponse;
+    type Response = WebResponse;
+    type Error = Infallible;
 
-    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Self::Output {
-        ctx.into_response(self)
+    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+        Ok(ctx.into_response(self))
     }
 }

--- a/web/src/handler/types/websocket.rs
+++ b/web/src/handler/types/websocket.rs
@@ -171,9 +171,10 @@ impl<'r, C, B> Responder<WebContext<'r, C, B>> for WebSocket<B>
 where
     B: BodyStream + 'static,
 {
-    type Output = WebResponse;
+    type Response = WebResponse;
+    type Error = Infallible;
 
-    async fn respond_to(self, _: WebContext<'r, C, B>) -> Self::Output {
+    async fn respond_to(self, _: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         let Self {
             ws,
             ping_interval,
@@ -195,7 +196,7 @@ where
             on_close,
         ));
 
-        res.map(ResponseBody::box_stream)
+        Ok(res.map(ResponseBody::box_stream))
     }
 }
 


### PR DESCRIPTION
`Responder` trait now output `Result<Response, Error>` type. The associate `Responder::Error` type would be converted to `FromRequest::Error` utilizing `From` trait. This would help reducing nesting of output type where a `Result<Result<_, Responder::Error>, FromRequest::Error>` can be converted to `Result<_, FromRequest::Error>` with `impl From<Responder::Error> for FromRequest::Error`.

add example for xitca-web error handling.