### PR TITLE
add Group middleware.

### DIFF
--- a/examples/multi-http-services/src/main.rs
+++ b/examples/multi-http-services/src/main.rs
@@ -17,7 +17,7 @@ use xitca_http::{
     util::middleware::{Logger, SocketConfig},
     HttpServiceBuilder, ResponseBody,
 };
-use xitca_service::{fn_build_nop, fn_service, ServiceExt};
+use xitca_service::{fn_service, middleware::Group, ServiceExt};
 
 fn main() -> io::Result<()> {
     tracing_subscriber::fmt()
@@ -61,7 +61,7 @@ fn main() -> io::Result<()> {
             config,
             fn_service(handler_h3).enclosed(
                 // a show case of nested enclosed middleware
-                fn_build_nop()
+                Group::new()
                     .enclosed(HttpServiceBuilder::h3())
                     .enclosed(Logger::default()),
             ),

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -47,7 +47,7 @@ pub mod ready;
 pub use self::{
     async_closure::AsyncClosure,
     pipeline::{EnclosedFactory, EnclosedFnFactory, MapErrorServiceFactory},
-    service::{fn_build, fn_build_nop, fn_service, FnService, Service, ServiceExt},
+    service::{fn_build, fn_service, FnService, Service, ServiceExt},
 };
 
 #[cfg(feature = "alloc")]

--- a/service/src/middleware/group.rs
+++ b/service/src/middleware/group.rs
@@ -8,7 +8,6 @@ use crate::service::Service;
 /// ```rust
 /// # use core::convert::Infallible;
 /// # use xitca_service::{fn_service, middleware::Group, Service, ServiceExt};
-///
 /// // a simple passthrough middleware function.
 /// async fn mw<S, Req>(svc: &S, req: Req) -> Result<S::Response, S::Error>
 /// where
@@ -17,14 +16,13 @@ use crate::service::Service;
 ///     svc.call(req).await
 /// }
 ///
-/// # fn nest() {
 /// fn_service(|_: ()| async { Ok::<_, Infallible>(()) })
 ///     .enclosed(
-///         Group::new() // group multiple middlewares and apply it to other service.
+///         // group multiple middlewares and apply it to fn_service.
+///         Group::new()
 ///             .enclosed_fn(mw)
 ///             .enclosed_fn(mw)
 ///     );
-/// # }
 /// ```
 pub struct Group<S, E>(PhantomData<fn(S, E)>);
 

--- a/service/src/middleware/group.rs
+++ b/service/src/middleware/group.rs
@@ -1,0 +1,44 @@
+use core::marker::PhantomData;
+
+use crate::service::Service;
+
+/// middleware builder type for grouping and nesting multiple middlewares.
+///
+/// # Examples
+/// ```rust
+/// # use core::convert::Infallible;
+/// # use xitca_service::{fn_service, middleware::Group, Service, ServiceExt};
+///
+/// // a simple passthrough middleware function.
+/// async fn mw<S, Req>(svc: &S, req: Req) -> Result<S::Response, S::Error>
+/// where
+///     S: Service<Req>
+/// {
+///     svc.call(req).await
+/// }
+///
+/// # fn nest() {
+/// fn_service(|_: ()| async { Ok::<_, Infallible>(()) })
+///     .enclosed(
+///         Group::new() // group multiple middlewares and apply it to other service.
+///             .enclosed_fn(mw)
+///             .enclosed_fn(mw)
+///     );
+/// # }
+/// ```
+pub struct Group<S, E>(PhantomData<fn(S, E)>);
+
+impl<S, E> Group<S, E> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<S, E> Service<Result<S, E>> for Group<S, E> {
+    type Response = S;
+    type Error = E;
+
+    async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
+        res
+    }
+}

--- a/service/src/middleware/mod.rs
+++ b/service/src/middleware/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! [ServiceExt::enclosed]: crate::service::ServiceExt::enclosed
 
+mod group;
 mod unchecked_ready;
 
+pub use group::Group;
 pub use unchecked_ready::UncheckedReady;

--- a/service/src/service/function.rs
+++ b/service/src/service/function.rs
@@ -14,39 +14,6 @@ where
     FnService(f)
 }
 
-/// Shortcut for infering generic type param of [Service] trait implements.
-/// Often used to help type infering when nesting [ServiceExt::enclosed] or
-/// [ServiceExt::enclosed_fn]
-///
-/// # Examples
-/// ```rust
-/// # use core::convert::Infallible;
-/// # use xitca_service::{fn_build_nop, fn_service, Service, ServiceExt};
-///
-/// // a simple passthrough middleware function.
-/// async fn mw<S, Req>(svc: &S, req: Req) -> Result<S::Response, S::Error>
-/// where
-///     S: Service<Req>
-/// {
-///     svc.call(req).await
-/// }
-///
-/// # fn nest() {
-/// fn_service(|_: ()| async { Ok::<_, Infallible>(()) })
-///     .enclosed(
-///         fn_build_nop() // use nop build service for nested middleware function.
-///             .enclosed_fn(mw)
-///             .enclosed_fn(mw)
-///     );
-/// # }
-/// ```
-///
-/// [ServiceExt::enclosed]: super::ServiceExt::enclosed
-/// [ServiceExt::enclosed_fn]: super::ServiceExt::enclosed_fn
-pub fn fn_build_nop<S, E>() -> FnService<impl Fn(Result<S, E>) -> Ready<Result<S, E>> + Clone> {
-    fn_build(ready)
-}
-
 /// Shortcut for transform a given Fn into type impl [Service] trait.
 pub fn fn_service<F, Req, Fut, Res, Err>(
     f: F,

--- a/service/src/service/mod.rs
+++ b/service/src/service/mod.rs
@@ -9,7 +9,7 @@ mod opt;
 
 pub use self::{
     ext::ServiceExt,
-    function::{fn_build, fn_build_nop, fn_service, FnService},
+    function::{fn_build, fn_service, FnService},
 };
 
 use core::{future::Future, ops::Deref, pin::Pin};


### PR DESCRIPTION
remove `xitca_service::fn_build_nop` and `Group` would take it's role. For better naming and module placement.