### PR TITLE
use concrete request body type for App.

### DIFF
--- a/examples/macros/src/main.rs
+++ b/examples/macros/src/main.rs
@@ -31,9 +31,17 @@ where
     })
 }
 
-// routing function with given path and http method.
-// after the route service is constructed it would be enclosed by given middleware_fn.
-#[route("/", method = get, enclosed_fn = middleware_fn)]
+// decorate async function handler with route macro.
+#[route(
+    // string path of route that registered wit router. incoming http request would match it's uri against the path.
+    "/", 
+    // http method of route that registered with route.
+    method = get,
+    // enclosed async function handler with given middleware function.
+    enclosed_fn = middleware_fn,
+    // multiple middlewares can be applied.
+    enclosed_fn = middleware_fn
+)]
 async fn root(StateRef(s): StateRef<'_, String>) -> String {
     s.to_owned()
 }

--- a/web/src/handler/types/state.rs
+++ b/web/src/handler/types/state.rs
@@ -87,10 +87,9 @@ mod test {
     use super::*;
 
     use xitca_codegen::State;
-    use xitca_http::Request;
     use xitca_unsafe_collection::futures::NowOrPanic;
 
-    use crate::{handler::handler_service, route::get, service::Service, App};
+    use crate::{handler::handler_service, http::WebRequest, route::get, service::Service, App};
 
     #[derive(State, Clone, Debug, Eq, PartialEq)]
     struct State {
@@ -127,7 +126,7 @@ mod test {
             .now_or_panic()
             .ok()
             .unwrap()
-            .call(Request::default())
+            .call(WebRequest::default())
             .now_or_panic()
             .unwrap();
     }

--- a/web/src/middleware/limit.rs
+++ b/web/src/middleware/limit.rs
@@ -179,7 +179,7 @@ mod test {
         bytes::Bytes,
         error::BodyError,
         handler::{body::Body, handler_service},
-        http::{Request, RequestExt},
+        http::WebRequest,
         test::collect_body,
         App,
     };
@@ -205,8 +205,7 @@ mod test {
         let item = || async { Ok::<_, BodyError>(Bytes::from_static(chunk)) };
 
         let body = stream::once(item()).chain(stream::once(item()));
-        let ext = RequestExt::default().map_body(|_: ()| BoxBody::new(body));
-        let req = Request::new(ext);
+        let req = WebRequest::default().map(|ext| ext.map_body(|_: ()| BoxBody::new(body).into()));
 
         let body = App::new()
             .at("/", handler_service(handler))

--- a/web/src/middleware/mod.rs
+++ b/web/src/middleware/mod.rs
@@ -12,7 +12,7 @@ pub mod limit;
 pub mod sync;
 
 pub use xitca_http::util::middleware::{Extension, Logger};
-pub use xitca_service::middleware::UncheckedReady;
+pub use xitca_service::middleware::{Group, UncheckedReady};
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Instead of accepting generic B: Stream type as request body. `App` now always expect `xitca_web::body::RequestBody` type.
For testing purpose all request body type must be convert to `RequestBody` before passing to app service. 
Multiple `From` trait implement has been added to ease this process.