### PR TITLE
remove generic B type from route macro and examples.

### DIFF
--- a/codegen/src/route.rs
+++ b/codegen/src/route.rs
@@ -116,16 +116,15 @@ pub(crate) fn route(attr: Args, input: ItemFn) -> Result<TokenStream, Error> {
         #[allow(non_camel_case_types)]
         #vis struct #ident;
 
-        impl<C, B> ::xitca_web::codegen::__private::TypedRoute<(C, B)> for #ident
+        impl<C> ::xitca_web::codegen::__private::TypedRoute<C> for #ident
         where
             // TODO: not every state is bound to Send,Sync,Clone.
-            C: #state Send + Sync + Clone + 'static,
-            B: ::xitca_web::body::BodyStream + 'static
+            C: #state Send + Sync + Clone + 'static
         {
             type Route = ::xitca_web::service::object::BoxedSyncServiceObject<
                 (),
                 Box<dyn for<'r> ::xitca_web::service::object::ServiceObject<
-                    ::xitca_web::WebContext<'r, C, B>,
+                    ::xitca_web::WebContext<'r, C>,
                     Response = ::xitca_web::http::WebResponse,
                     Error = ::xitca_web::error::RouterError<::xitca_web::error::Error<C>>
                 >>,
@@ -144,7 +143,7 @@ pub(crate) fn route(attr: Args, input: ItemFn) -> Result<TokenStream, Error> {
                 use xitca_web::route::#method;
                 use xitca_web::service::ServiceExt;
 
-                WebContext::<'_, C, B>::into_object(#method(#handler(#ident)#middlewares))
+                WebContext::<'_, C>::into_object(#method(#handler(#ident)#middlewares))
             }
         }
     }

--- a/examples/error-handle/src/main.rs
+++ b/examples/error-handle/src/main.rs
@@ -69,9 +69,9 @@ impl<'r, C> Service<WebContext<'r, C>> for MyError {
 }
 
 // a middleware function used for intercept and interact with app handler outputs.
-async fn error_handler<S, C, B, Res>(s: &S, ctx: WebContext<'_, C, B>) -> Result<Res, Error<C>>
+async fn error_handler<S, C, Res>(s: &S, ctx: WebContext<'_, C>) -> Result<Res, Error<C>>
 where
-    S: for<'r> Service<WebContext<'r, C, B>, Response = Res, Error = Error<C>>,
+    S: for<'r> Service<WebContext<'r, C>, Response = Res, Error = Error<C>>,
 {
     s.call(ctx).await.map_err(|e| {
         // debug format error info.

--- a/examples/macros/src/main.rs
+++ b/examples/macros/src/main.rs
@@ -5,7 +5,10 @@ use xitca_web::{
     codegen::{error_impl, route},
     handler::state::{StateOwn, StateRef},
     http::{StatusCode, WebResponse},
-    middleware::{Logger, sync::{SyncMiddleware, Next}},
+    middleware::{
+        sync::{Next, SyncMiddleware},
+        Logger,
+    },
     service::Service,
     App, WebContext,
 };
@@ -23,9 +26,9 @@ fn main() -> std::io::Result<()> {
 }
 
 // a simple middleware function forward request to other services and display response status code.
-async fn middleware_fn<S, C, B, Err>(s: &S, ctx: WebContext<'_, C, B>) -> Result<WebResponse, Err>
+async fn middleware_fn<S, C, Err>(s: &S, ctx: WebContext<'_, C>) -> Result<WebResponse, Err>
 where
-    S: for<'r> Service<WebContext<'r, C, B>, Response = WebResponse, Error = Err>,
+    S: for<'r> Service<WebContext<'r, C>, Response = WebResponse, Error = Err>,
 {
     s.call(ctx).await.map(|res| {
         tracing::info!("response status: {}", res.status());

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -118,9 +118,9 @@ impl<CF, Obj> App<CF, AppRouter<Obj>> {
     }
 
     /// insert typed route service with given path to application.
-    pub fn at_typed<T, C, B>(mut self, typed: T) -> App<CF, AppRouter<Obj>>
+    pub fn at_typed<T, C>(mut self, typed: T) -> App<CF, AppRouter<Obj>>
     where
-        T: TypedRoute<(C, B), Route = Obj>,
+        T: TypedRoute<C, Route = Obj>,
     {
         self.router = AppRouter(self.router.0.insert_typed(typed));
         self

--- a/web/src/middleware/decompress.rs
+++ b/web/src/middleware/decompress.rs
@@ -12,6 +12,12 @@ use crate::{
 /// A decompress middleware look into [WebContext]'s `Content-Encoding` header and
 /// apply according decompression to it according to enabled compress feature.
 /// `compress-x` feature must be enabled for this middleware to function correctly.
+///
+/// # Type mutation
+/// `Decompress` would mutate request body type from `B` to `Coder<B>`. Service enclosed
+/// by it must be able to handle it's mutation or utilize [TypeEraser] to erase the mutation.
+///
+/// [TypeEraser]: crate::middleware::eraser::TypeEraser
 #[derive(Clone)]
 pub struct Decompress;
 

--- a/web/src/middleware/limit.rs
+++ b/web/src/middleware/limit.rs
@@ -1,3 +1,5 @@
+//! limitation middleware.
+
 use std::{
     cell::RefCell,
     convert::Infallible,
@@ -17,6 +19,13 @@ use crate::{
     service::{pipeline::PipelineE, ready::ReadyService, Service},
 };
 
+/// General purposed limitation middleware. Limiting request/response body size etc.
+///
+/// # Type mutation
+/// `Limit` would mutate request body type from `B` to `Limit<B>`. Service enclosed
+/// by it must be able to handle it's mutation or utilize [TypeEraser] to erase the mutation.
+///
+/// [TypeEraser]: crate::middleware::eraser::TypeEraser
 #[derive(Copy, Clone)]
 pub struct Limit {
     request_body_size: usize,
@@ -29,7 +38,7 @@ impl Default for Limit {
 }
 
 impl Limit {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             request_body_size: usize::MAX,
         }


### PR DESCRIPTION
Besides rare use case `WebContext<'_, C, B>` can most time be simplified to `WebContext<'_, C>`.