### PR TITLE
rework stream body type.

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -2,7 +2,7 @@
 
 use std::{convert::Infallible, error, fmt, io, str};
 
-use xitca_http::{error::BodyError, http::uri};
+use xitca_http::http::uri;
 
 #[derive(Debug)]
 #[non_exhaustive]
@@ -13,7 +13,6 @@ pub enum Error {
     Resolve,
     Timeout(TimeoutError),
     TlsNotEnabled,
-    Body(BodyError),
     #[cfg(feature = "http1")]
     H1(crate::h1::Error),
     #[cfg(feature = "http2")]
@@ -44,12 +43,6 @@ impl From<io::Error> for Error {
 impl From<Box<dyn error::Error + Send + Sync>> for Error {
     fn from(e: Box<dyn error::Error + Send + Sync>) -> Self {
         Self::Std(e)
-    }
-}
-
-impl From<BodyError> for Error {
-    fn from(e: BodyError) -> Self {
-        Self::Body(e)
     }
 }
 

--- a/client/src/h1/error.rs
+++ b/client/src/h1/error.rs
@@ -1,13 +1,12 @@
 use std::{error, io};
 
-use xitca_http::{error::BodyError, h1::proto::error::ProtoError};
+use xitca_http::h1::proto::error::ProtoError;
 
 #[derive(Debug)]
 pub enum Error {
     Std(Box<dyn error::Error + Send + Sync>),
     Io(io::Error),
     Proto(ProtoError),
-    Body(BodyError),
 }
 
 impl From<Box<dyn error::Error + Send + Sync>> for Error {
@@ -25,11 +24,5 @@ impl From<io::Error> for Error {
 impl From<ProtoError> for Error {
     fn from(e: ProtoError) -> Self {
         Self::Proto(e)
-    }
-}
-
-impl From<BodyError> for Error {
-    fn from(e: BodyError) -> Self {
-        Self::Body(e)
     }
 }

--- a/examples/grpc/src/main.rs
+++ b/examples/grpc/src/main.rs
@@ -41,7 +41,7 @@ async fn grpc(mut req: Request<RequestExt<RequestBody>>) -> Result<Response<Once
 
     let mut buf = BytesMut::new();
 
-    while let Some(bytes) = body.try_next().await? {
+    while let Some(bytes) = body.try_next().await.map_err(|e| anyhow::anyhow! {e})? {
         buf.extend_from_slice(bytes.as_ref());
     }
 

--- a/examples/multipart/src/main.rs
+++ b/examples/multipart/src/main.rs
@@ -4,7 +4,6 @@ use std::{io, pin::pin};
 
 use tracing::info;
 use xitca_web::{
-    error::Error,
     handler::{handler_service, multipart::Multipart},
     route::post,
     App,
@@ -20,7 +19,9 @@ fn main() -> io::Result<()> {
         .wait()
 }
 
-async fn root(multipart: Multipart) -> Result<&'static str, Error<()>> {
+type Error = Box<dyn std::error::Error + Send + Sync>;
+
+async fn root(multipart: Multipart) -> Result<&'static str, Error> {
     // pin multipart on stack for async stream handling.
     let mut multipart = pin!(multipart);
 

--- a/http-encoding/src/error.rs
+++ b/http-encoding/src/error.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt, io};
+use std::{error, fmt};
 
 /// Error occur when trying to construct decode/encode request/response.
 #[derive(Debug)]
@@ -53,49 +53,4 @@ impl From<FeatureError> for EncodingError {
 }
 
 /// Error occur when decode/encode request/response body stream.
-pub enum CoderError<E> {
-    Io(io::Error),
-    Stream(E),
-}
-
-impl<E> fmt::Debug for CoderError<E>
-where
-    E: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Io(ref e) => fmt::Debug::fmt(e, f),
-            Self::Stream(ref e) => fmt::Debug::fmt(e, f),
-        }
-    }
-}
-
-impl<E> fmt::Display for CoderError<E>
-where
-    E: fmt::Display,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Io(ref e) => fmt::Display::fmt(e, f),
-            Self::Stream(ref e) => fmt::Display::fmt(e, f),
-        }
-    }
-}
-
-impl<E> error::Error for CoderError<E>
-where
-    E: error::Error,
-{
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match *self {
-            Self::Io(ref e) => e.source(),
-            Self::Stream(ref e) => e.source(),
-        }
-    }
-}
-
-impl<E> From<io::Error> for CoderError<E> {
-    fn from(e: io::Error) -> Self {
-        Self::Io(e)
-    }
-}
+pub type CoderError = Box<dyn error::Error + Send + Sync>;

--- a/http-multipart/src/content_disposition.rs
+++ b/http-multipart/src/content_disposition.rs
@@ -14,7 +14,7 @@ impl ContentDisposition {
     const NAME: &'static [u8; 5] = b"name=";
     const FILE_NAME: &'static [u8; 9] = b"filename=";
 
-    pub(super) fn try_from_header<E>(headers: &HeaderMap) -> Result<Self, MultipartError<E>> {
+    pub(super) fn try_from_header(headers: &HeaderMap) -> Result<Self, MultipartError> {
         let header = headers
             .get(&CONTENT_DISPOSITION)
             .ok_or(MultipartError::NoContentDisposition)?

--- a/http-multipart/src/header.rs
+++ b/http-multipart/src/header.rs
@@ -5,7 +5,7 @@ use memchr::memmem;
 use super::error::MultipartError;
 
 /// Extract boundary info from headers.
-pub(super) fn boundary<E>(headers: &HeaderMap) -> Result<&[u8], MultipartError<E>> {
+pub(super) fn boundary(headers: &HeaderMap) -> Result<&[u8], MultipartError> {
     let header = headers
         .get(&CONTENT_TYPE)
         .ok_or(MultipartError::NoContentType)?
@@ -20,7 +20,7 @@ pub(super) fn boundary<E>(headers: &HeaderMap) -> Result<&[u8], MultipartError<E
     Ok(&header[start..end])
 }
 
-pub(super) fn parse_headers<E>(headers: &mut HeaderMap, slice: &[u8]) -> Result<(), MultipartError<E>> {
+pub(super) fn parse_headers(headers: &mut HeaderMap, slice: &[u8]) -> Result<(), MultipartError> {
     let mut hdrs = [EMPTY_HEADER; 16];
     match httparse::parse_headers(slice, &mut hdrs)? {
         httparse::Status::Complete((_, hdrs)) => {
@@ -39,7 +39,7 @@ pub(super) fn parse_headers<E>(headers: &mut HeaderMap, slice: &[u8]) -> Result<
     }
 }
 
-pub(super) fn check_headers<E>(headers: &HeaderMap) -> Result<(), MultipartError<E>> {
+pub(super) fn check_headers(headers: &HeaderMap) -> Result<(), MultipartError> {
     let ct = headers
         .get(&CONTENT_TYPE)
         .and_then(|ct| ct.to_str().ok())
@@ -54,7 +54,7 @@ pub(super) fn check_headers<E>(headers: &HeaderMap) -> Result<(), MultipartError
     Ok(())
 }
 
-pub(super) fn content_length_opt<E>(headers: &HeaderMap) -> Result<Option<u64>, MultipartError<E>> {
+pub(super) fn content_length_opt(headers: &HeaderMap) -> Result<Option<u64>, MultipartError> {
     match headers.get(&CONTENT_LENGTH) {
         Some(len) => {
             let len = len

--- a/http/src/error.rs
+++ b/http/src/error.rs
@@ -3,8 +3,7 @@
 use std::{
     convert::Infallible,
     error::Error,
-    fmt::{self, Debug, Display, Formatter},
-    io,
+    fmt::{self, Debug, Formatter},
 };
 
 use tracing::error;
@@ -86,40 +85,4 @@ impl<S, B> From<Infallible> for HttpServiceError<S, B> {
 }
 
 /// Default Request/Response body error.
-#[derive(Debug)]
-pub struct BodyError(Box<dyn Error + Send + Sync>);
-
-impl BodyError {
-    pub fn from_error<E>(e: E) -> Self
-    where
-        E: Error + Send + Sync + 'static,
-    {
-        Self(Box::new(e))
-    }
-}
-
-impl Display for BodyError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.0, f)
-    }
-}
-
-impl Error for BodyError {}
-
-impl From<io::Error> for BodyError {
-    fn from(e: io::Error) -> Self {
-        Self(Box::new(e))
-    }
-}
-
-impl From<Box<dyn Error + Send + Sync>> for BodyError {
-    fn from(e: Box<dyn Error + Send + Sync>) -> Self {
-        Self(e)
-    }
-}
-
-impl From<Infallible> for BodyError {
-    fn from(e: Infallible) -> BodyError {
-        match e {}
-    }
-}
+pub type BodyError = Box<dyn Error + Send + Sync>;

--- a/http/src/h2/error.rs
+++ b/http/src/h2/error.rs
@@ -1,4 +1,4 @@
-use crate::error::{BodyError, HttpServiceError};
+use crate::error::HttpServiceError;
 
 #[derive(Debug)]
 pub enum Error<S, B> {
@@ -26,11 +26,5 @@ impl<S, B> From<Error<S, B>> for HttpServiceError<S, B> {
 impl<S, B> From<::h2::Error> for HttpServiceError<S, B> {
     fn from(e: ::h2::Error) -> Self {
         Self::H2(Error::H2(e))
-    }
-}
-
-impl From<::h2::Error> for BodyError {
-    fn from(e: ::h2::Error) -> Self {
-        BodyError::from(Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
     }
 }

--- a/http/src/h3/error.rs
+++ b/http/src/h3/error.rs
@@ -1,6 +1,6 @@
 use h3_quinn::quinn::ConnectionError;
 
-use crate::error::{BodyError, HttpServiceError};
+use crate::error::HttpServiceError;
 
 #[derive(Debug)]
 pub enum Error<S, B> {
@@ -29,11 +29,5 @@ impl<S, B> From<Error<S, B>> for HttpServiceError<S, B> {
             Error::Service(e) => Self::Service(e),
             e => Self::H3(e),
         }
-    }
-}
-
-impl From<::h3::Error> for BodyError {
-    fn from(e: ::h3::Error) -> Self {
-        BodyError::from(Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
     }
 }

--- a/web/src/body.rs
+++ b/web/src/body.rs
@@ -1,22 +1,22 @@
 //! http body types and traits.
 
-use std::error;
-
 use futures_core::stream::Stream;
 
 pub use xitca_http::body::{none_body_hint, BoxBody, RequestBody, ResponseBody, NONE_BODY_HINT};
 
+use crate::error::BodyError;
+
 /// an extended trait for [Stream] that specify additional type info of the [Stream::Item] type.
 pub trait BodyStream: Stream<Item = Result<Self::Chunk, Self::Error>> {
     type Chunk: AsRef<[u8]> + 'static;
-    type Error: error::Error + Send + Sync + 'static;
+    type Error: Into<BodyError>;
 }
 
 impl<S, T, E> BodyStream for S
 where
     S: Stream<Item = Result<T, E>>,
     T: AsRef<[u8]> + 'static,
-    E: error::Error + Send + Sync + 'static,
+    E: Into<BodyError>,
 {
     type Chunk = T;
     type Error = E;

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -194,9 +194,9 @@ impl<C> From<io::Error> for Error<C> {
     }
 }
 
-impl<C> From<BodyError> for Error<C> {
-    fn from(e: BodyError) -> Self {
-        Self::from_service(e)
+impl<C> From<Box<dyn error::Error + Send + Sync>> for Error<C> {
+    fn from(e: Box<dyn error::Error + Send + Sync>) -> Self {
+        Self(Box::new(StdError(e)))
     }
 }
 
@@ -206,6 +206,31 @@ impl<'r, C> Service<WebContext<'r, C>> for Error<C> {
 
     async fn call(&self, ctx: WebContext<'r, C>) -> Result<Self::Response, Self::Error> {
         crate::service::object::ServiceObject::call(self.deref(), ctx).await
+    }
+}
+
+pub struct StdError(Box<dyn error::Error + Send + Sync>);
+
+impl fmt::Debug for StdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for StdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl error::Error for StdError {}
+
+impl<'r, C, B> Service<WebContext<'r, C, B>> for StdError {
+    type Response = WebResponse;
+    type Error = Infallible;
+
+    async fn call(&self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+        self.0.call(ctx).await
     }
 }
 
@@ -252,9 +277,6 @@ blank_error_service!(BadRequest, StatusCode::BAD_REQUEST);
 
 blank_error_service!(MatchError, StatusCode::NOT_FOUND);
 blank_error_service!(io::Error, StatusCode::INTERNAL_SERVER_ERROR);
-blank_error_service!(BodyError, StatusCode::BAD_REQUEST);
-blank_error_service!(Box<dyn error::Error>, StatusCode::INTERNAL_SERVER_ERROR);
-blank_error_service!(Box<dyn error::Error + Send>, StatusCode::INTERNAL_SERVER_ERROR);
 blank_error_service!(Box<dyn error::Error + Send + Sync>, StatusCode::INTERNAL_SERVER_ERROR);
 
 impl<'r, C, B> Service<WebContext<'r, C, B>> for Infallible {

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -209,7 +209,7 @@ impl<'r, C> Service<WebContext<'r, C>> for Error<C> {
     }
 }
 
-pub struct StdError(Box<dyn error::Error + Send + Sync>);
+pub struct StdError(pub Box<dyn error::Error + Send + Sync>);
 
 impl fmt::Debug for StdError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/web/src/handler/types/json.rs
+++ b/web/src/handler/types/json.rs
@@ -14,7 +14,7 @@ use crate::{
     body::BodyStream,
     bytes::{BufMutWriter, BytesMut},
     context::WebContext,
-    error::{BadRequest, BodyError, Error},
+    error::{BadRequest, Error},
     handler::{FromRequest, Responder},
     http::{const_header_value::JSON, header::CONTENT_TYPE, WebResponse},
     service::Service,
@@ -84,7 +84,7 @@ where
         let mut buf = BytesMut::new();
 
         while let Some(chunk) = poll_fn(|cx| body.as_mut().poll_next(cx)).await {
-            let chunk = chunk.map_err(BodyError::from_error)?;
+            let chunk = chunk.map_err(Into::into)?;
             buf.extend_from_slice(chunk.as_ref());
             if buf.len() > limit {
                 break;

--- a/web/src/handler/types/multipart.rs
+++ b/web/src/handler/types/multipart.rs
@@ -1,7 +1,5 @@
 use core::convert::Infallible;
 
-use std::error;
-
 use crate::{
     body::{BodyStream, RequestBody},
     context::WebContext,
@@ -26,16 +24,13 @@ where
     }
 }
 
-impl<E, C> From<http_multipart::MultipartError<E>> for Error<C>
-where
-    E: error::Error + Send + Sync + 'static,
-{
-    fn from(e: http_multipart::MultipartError<E>) -> Self {
+impl<C> From<http_multipart::MultipartError> for Error<C> {
+    fn from(e: http_multipart::MultipartError) -> Self {
         Error::from_service(e)
     }
 }
 
-impl<'r, C, B, E> Service<WebContext<'r, C, B>> for http_multipart::MultipartError<E> {
+impl<'r, C, B> Service<WebContext<'r, C, B>> for http_multipart::MultipartError {
     type Response = WebResponse;
     type Error = Infallible;
 

--- a/web/src/handler/types/vec.rs
+++ b/web/src/handler/types/vec.rs
@@ -3,7 +3,7 @@ use core::{convert::Infallible, future::poll_fn, pin::pin};
 use crate::{
     body::BodyStream,
     context::WebContext,
-    error::{BodyError, Error},
+    error::Error,
     handler::{FromRequest, Responder},
     http::WebResponse,
 };
@@ -24,7 +24,7 @@ where
         let mut vec = Vec::new();
 
         while let Some(chunk) = poll_fn(|cx| body.as_mut().poll_next(cx)).await {
-            let chunk = chunk.map_err(BodyError::from_error)?;
+            let chunk = chunk.map_err(Into::into)?;
             vec.extend_from_slice(chunk.as_ref());
         }
 

--- a/web/src/middleware/eraser.rs
+++ b/web/src/middleware/eraser.rs
@@ -128,7 +128,6 @@ where
     S: for<'rs> Service<WebContext<'rs, C>, Response = WebResponse<ResB>, Error = Err>,
     ReqB: BodyStream<Chunk = Bytes> + Default + 'static,
     ResB: BodyStream<Chunk = Bytes> + 'static,
-    <ResB as BodyStream>::Error: Send + Sync,
 {
     type Response = WebResponse;
     type Error = Err;


### PR DESCRIPTION
remove typed `BodyError`. all body related error type are type alias of `Box<dyn std::error::Error + Send + Sync>`