### PR TITLE
fix error service handling.

### DIFF
--- a/web/src/body.rs
+++ b/web/src/body.rs
@@ -4,6 +4,8 @@ use futures_core::stream::Stream;
 
 pub use xitca_http::body::{none_body_hint, BoxBody, RequestBody, ResponseBody, NONE_BODY_HINT};
 
+pub(crate) use xitca_http::body::Either;
+
 use crate::error::BodyError;
 
 /// an extended trait for [Stream] that specify additional type info of the [Stream::Item] type.

--- a/web/src/middleware/compress.rs
+++ b/web/src/middleware/compress.rs
@@ -9,6 +9,13 @@ use crate::{
 /// A compress middleware look into [WebRequest]'s `Accept-Encoding` header and
 /// apply according compression to [WebResponse]'s body according to enabled compress feature.
 /// `compress-x` feature must be enabled for this middleware to function correctly.
+///
+/// # Type mutation
+/// `Compress` would mutate response body type from `B` to `Coder<B>`. Service enclosed
+/// by it must be able to handle it's mutation or utilize [TypeEraser] to erase the mutation.
+///
+/// [WebRequest]: crate::http::WebRequest
+/// [TypeEraser]: crate::middleware::eraser::TypeEraser
 #[derive(Clone)]
 pub struct Compress;
 

--- a/web/src/middleware/compress.rs
+++ b/web/src/middleware/compress.rs
@@ -66,3 +66,31 @@ where
         self.0.ready().await
     }
 }
+
+#[cfg(test)]
+mod test {
+    use xitca_unsafe_collection::futures::NowOrPanic;
+
+    use crate::{handler::handler_service, http::WebRequest, App};
+
+    use super::*;
+
+    #[test]
+    fn build() {
+        async fn noop() -> &'static str {
+            "noop"
+        }
+
+        App::new()
+            .at("/", handler_service(noop))
+            .enclosed(Compress)
+            .finish()
+            .call(())
+            .now_or_panic()
+            .unwrap()
+            .call(WebRequest::default())
+            .now_or_panic()
+            .ok()
+            .unwrap();
+    }
+}

--- a/web/src/service/tower_http_compat.rs
+++ b/web/src/service/tower_http_compat.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// A middleware type that bridge `xitca-service` and `tower-service`.
-/// Any `tower-http` type that impl [tower::Service] trait can be passed to it and used as xitca-web's service type.
+/// Any `tower-http` type that impl [tower_service::Service] trait can be passed to it and used as xitca-web's service type.
 pub struct TowerHttpCompat<S> {
     service: S,
 }


### PR DESCRIPTION
`xitca_web::error::Error` does not drop streaming response body anymore. therefore streaming error to client is fixed.