### PR TITLE
service type alias renaming

### DIFF
--- a/http/src/util/service/router_priv.rs
+++ b/http/src/util/service/router_priv.rs
@@ -6,8 +6,9 @@ use std::{borrow::Cow, collections::HashMap, error};
 
 use xitca_service::{
     object::{BoxedServiceObject, BoxedSyncServiceObject},
+    pipeline::PipelineT,
     ready::ReadyService,
-    EnclosedBuilder, EnclosedFnBuilder, FnService, MapBuilder, MapErrorBuilder, Service,
+    FnService, Service,
 };
 
 use crate::http::{BorrowReq, BorrowReqMut, Request, Uri};
@@ -182,52 +183,7 @@ impl<F> RouterGen for FnService<F> {
     }
 }
 
-impl<F, S> RouterGen for MapBuilder<F, S>
-where
-    F: RouterGen,
-{
-    type Route<R> = F::Route<R>;
-
-    fn path_gen(&mut self, prefix: &'static str) -> Cow<'static, str> {
-        self.first.path_gen(prefix)
-    }
-
-    fn route_gen<R>(route: R) -> Self::Route<R> {
-        F::route_gen(route)
-    }
-}
-
-impl<F, S> RouterGen for MapErrorBuilder<F, S>
-where
-    F: RouterGen,
-{
-    type Route<R> = F::Route<R>;
-
-    fn path_gen(&mut self, prefix: &'static str) -> Cow<'static, str> {
-        self.first.path_gen(prefix)
-    }
-
-    fn route_gen<R>(route: R) -> Self::Route<R> {
-        F::route_gen(route)
-    }
-}
-
-impl<F, S> RouterGen for EnclosedBuilder<F, S>
-where
-    F: RouterGen,
-{
-    type Route<R> = F::Route<R>;
-
-    fn path_gen(&mut self, prefix: &'static str) -> Cow<'static, str> {
-        self.first.path_gen(prefix)
-    }
-
-    fn route_gen<R>(route: R) -> Self::Route<R> {
-        F::route_gen(route)
-    }
-}
-
-impl<F, S> RouterGen for EnclosedFnBuilder<F, S>
+impl<F, S, M> RouterGen for PipelineT<F, S, M>
 where
     F: RouterGen,
 {

--- a/http/src/util/service/router_priv.rs
+++ b/http/src/util/service/router_priv.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, collections::HashMap, error};
 use xitca_service::{
     object::{BoxedServiceObject, BoxedSyncServiceObject},
     ready::ReadyService,
-    EnclosedFactory, EnclosedFnFactory, FnService, MapErrorServiceFactory, Service,
+    EnclosedBuilder, EnclosedFnBuilder, FnService, MapBuilder, MapErrorBuilder, Service,
 };
 
 use crate::http::{BorrowReq, BorrowReqMut, Request, Uri};
@@ -182,7 +182,7 @@ impl<F> RouterGen for FnService<F> {
     }
 }
 
-impl<F, S> RouterGen for MapErrorServiceFactory<F, S>
+impl<F, S> RouterGen for MapBuilder<F, S>
 where
     F: RouterGen,
 {
@@ -197,7 +197,7 @@ where
     }
 }
 
-impl<F, S> RouterGen for EnclosedFactory<F, S>
+impl<F, S> RouterGen for MapErrorBuilder<F, S>
 where
     F: RouterGen,
 {
@@ -212,7 +212,22 @@ where
     }
 }
 
-impl<F, S> RouterGen for EnclosedFnFactory<F, S>
+impl<F, S> RouterGen for EnclosedBuilder<F, S>
+where
+    F: RouterGen,
+{
+    type Route<R> = F::Route<R>;
+
+    fn path_gen(&mut self, prefix: &'static str) -> Cow<'static, str> {
+        self.first.path_gen(prefix)
+    }
+
+    fn route_gen<R>(route: R) -> Self::Route<R> {
+        F::route_gen(route)
+    }
+}
+
+impl<F, S> RouterGen for EnclosedFnBuilder<F, S>
 where
     F: RouterGen,
 {

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -46,7 +46,7 @@ pub mod ready;
 
 pub use self::{
     async_closure::AsyncClosure,
-    pipeline::{EnclosedFactory, EnclosedFnFactory, MapErrorServiceFactory},
+    pipeline::{EnclosedBuilder, EnclosedFnBuilder, MapBuilder, MapErrorBuilder},
     service::{fn_build, fn_service, FnService, Service, ServiceExt},
 };
 

--- a/service/src/pipeline/mod.rs
+++ b/service/src/pipeline/mod.rs
@@ -9,10 +9,13 @@ pub use r#enum::Pipeline as PipelineE;
 pub use r#struct::Pipeline as PipelineT;
 
 /// Type alias for specialized [PipelineT] type.
-pub type EnclosedFnFactory<F, S> = PipelineT<F, S, marker::BuildEnclosedFn>;
+pub type EnclosedFnBuilder<F, S> = PipelineT<F, S, marker::BuildEnclosedFn>;
 
 /// Type alias for specialized [PipelineT] type.
-pub type EnclosedFactory<F, S> = PipelineT<F, S, marker::BuildEnclosed>;
+pub type EnclosedBuilder<F, S> = PipelineT<F, S, marker::BuildEnclosed>;
 
 /// Type alias for specialized [PipelineT] type.
-pub type MapErrorServiceFactory<F, S> = PipelineT<F, S, marker::BuildMapErr>;
+pub type MapBuilder<F, S> = PipelineT<F, S, marker::BuildMap>;
+
+/// Type alias for specialized [PipelineT] type.
+pub type MapErrorBuilder<F, S> = PipelineT<F, S, marker::BuildMapErr>;

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -25,8 +25,8 @@ use crate::{
     http::{WebRequest, WebResponse},
     middleware::eraser::TypeEraser,
     service::{
-        object::BoxedSyncServiceObject, ready::ReadyService, AsyncClosure, EnclosedBuilder, EnclosedFnBuilder, Service,
-        ServiceExt,
+        object::BoxedSyncServiceObject, ready::ReadyService, AsyncClosure, EnclosedBuilder, EnclosedFnBuilder,
+        MapBuilder, Service, ServiceExt,
     },
 };
 
@@ -194,6 +194,19 @@ where
         App {
             builder: self.builder,
             router: self.router.enclosed_fn(transform),
+        }
+    }
+
+    /// Mutate `<<Self::Response as Service<Req>>::Future as Future>::Output` type with given
+    /// closure.
+    pub fn map<T, Res, ResMap>(self, mapper: T) -> App<MapBuilder<R, T>, CtxBuilder<C>>
+    where
+        T: Fn(Res) -> ResMap + Clone,
+        Self: Sized,
+    {
+        App {
+            builder: self.builder,
+            router: self.router.map(mapper),
         }
     }
 

--- a/web/src/app/mod.rs
+++ b/web/src/app/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     http::{WebRequest, WebResponse},
     middleware::eraser::TypeEraser,
     service::{
-        object::BoxedSyncServiceObject, ready::ReadyService, AsyncClosure, EnclosedFactory, EnclosedFnFactory, Service,
+        object::BoxedSyncServiceObject, ready::ReadyService, AsyncClosure, EnclosedBuilder, EnclosedFnBuilder, Service,
         ServiceExt,
     },
 };
@@ -176,7 +176,7 @@ where
 {
     /// Enclose App with middleware type.
     /// Middleware must impl [Service] trait.
-    pub fn enclosed<T>(self, transform: T) -> App<EnclosedFactory<R, T>, CtxBuilder<C>>
+    pub fn enclosed<T>(self, transform: T) -> App<EnclosedBuilder<R, T>, CtxBuilder<C>>
     where
         T: Service<Result<R::Response, R::Error>>,
     {
@@ -187,7 +187,7 @@ where
     }
 
     /// Enclose App with function as middleware type.
-    pub fn enclosed_fn<Req, T>(self, transform: T) -> App<EnclosedFnFactory<R, T>, CtxBuilder<C>>
+    pub fn enclosed_fn<Req, T>(self, transform: T) -> App<EnclosedFnBuilder<R, T>, CtxBuilder<C>>
     where
         T: for<'s> AsyncClosure<(&'s R::Response, Req)> + Clone,
     {


### PR DESCRIPTION
Rename `Pipeline<_, _, marker::_>` from `<marker>ServiceFactory` to `<marker>Builder`. add export of `Pipeline<_, _, marker::BuildMap>`