### PR TITLE
rework Responder trait.

### DIFF
--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -57,7 +57,7 @@
 //!         <h1>{err}</h1>\
 //!         </body>\
 //!         </html>");
-//!     return Ok(Html(html).respond_to(ctx).await?);
+//!     return Ok(Html(html).respond(ctx).await?);
 //!
 //!     // or by default the error value is returned in Result::Err and passed to parent services
 //!     // of App or other middlewares where eventually it would be converted to WebResponse.

--- a/web/src/handler/impls.rs
+++ b/web/src/handler/impls.rs
@@ -166,10 +166,9 @@ impl<'r, C, B> crate::service::Service<WebContext<'r, C, B>> for serde::de::valu
 
 #[cfg(test)]
 mod test {
-    use xitca_http::http::HeaderValue;
     use xitca_unsafe_collection::futures::NowOrPanic;
 
-    use crate::http::header::COOKIE;
+    use crate::http::header::{HeaderValue, COOKIE};
 
     use super::*;
 
@@ -201,7 +200,10 @@ mod test {
         let check_res = |res: WebResponse| {
             assert_eq!(res.status(), StatusCode::ACCEPTED);
             assert_eq!(res.headers().get(COOKIE).unwrap().to_str().unwrap(), "none");
-            assert_eq!(res.headers().get(CONTENT_TYPE).unwrap(), TEXT_UTF8);
+            assert_eq!(
+                res.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+                "text/plain; charset=utf-8"
+            );
         };
 
         let res = (StatusCode::ACCEPTED, headers.clone(), "hello,world!")

--- a/web/src/handler/impls.rs
+++ b/web/src/handler/impls.rs
@@ -105,12 +105,12 @@ impl<'r, C, B> Responder<WebContext<'r, C, B>> for StatusCode {
 
     async fn respond(self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         let res = ctx.into_response(Bytes::new());
-        Ok(<Self as Responder<WebContext<'r, C, B>>>::map(self, res).await)
+        <Self as Responder<WebContext<'r, C, B>>>::map(self, res)
     }
 
-    async fn map(self, mut res: Self::Response) -> Self::Response {
+    fn map(self, mut res: Self::Response) -> Result<Self::Response, Self::Error> {
         *res.status_mut() = self;
-        res
+        Ok(res)
     }
 }
 
@@ -120,12 +120,12 @@ impl<'r, C, B> Responder<WebContext<'r, C, B>> for HeaderMap {
 
     async fn respond(self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         let res = ctx.into_response(Bytes::new());
-        Ok(<Self as Responder<WebContext<'r, C, B>>>::map(self, res).await)
+        <Self as Responder<WebContext<'r, C, B>>>::map(self, res)
     }
 
-    async fn map(self, mut res: Self::Response) -> Self::Response {
+    fn map(self, mut res: Self::Response) -> Result<Self::Response, Self::Error> {
         res.headers_mut().extend(self);
-        res
+        Ok(res)
     }
 }
 
@@ -141,10 +141,10 @@ macro_rules! text_utf8 {
                 Ok(res)
             }
 
-            async fn map(self, res: Self::Response) -> Self::Response {
+            fn map(self, res: Self::Response) -> Result<Self::Response, Self::Error> {
                 let mut res = res.map(|_| self.into());
                 res.headers_mut().insert(CONTENT_TYPE, TEXT_UTF8);
-                res
+                Ok(res)
             }
         }
     };

--- a/web/src/handler/sync.rs
+++ b/web/src/handler/sync.rs
@@ -75,7 +75,7 @@ where
         let extract = T::Type::<'_>::from_request(&req).await?;
         let func = self.func.clone();
         let res = tokio::task::spawn_blocking(move || func.call(extract)).await.unwrap();
-        res.respond_to(req).await.map_err(Into::into)
+        res.respond(req).await.map_err(Into::into)
     }
 }
 

--- a/web/src/handler/types/html.rs
+++ b/web/src/handler/types/html.rs
@@ -29,7 +29,7 @@ where
     type Error = Infallible;
 
     #[inline]
-    async fn respond_to(self, ctx: WebContext<'r, C>) -> Result<Self::Response, Self::Error> {
+    async fn respond(self, ctx: WebContext<'r, C>) -> Result<Self::Response, Self::Error> {
         let mut res = ctx.into_response(self.0);
         res.headers_mut().insert(CONTENT_TYPE, TEXT_HTML_UTF8);
         Ok(res)

--- a/web/src/handler/types/html.rs
+++ b/web/src/handler/types/html.rs
@@ -34,4 +34,9 @@ where
         res.headers_mut().insert(CONTENT_TYPE, TEXT_HTML_UTF8);
         Ok(res)
     }
+
+    fn map(self, mut res: Self::Response) -> Result<Self::Response, Self::Error> {
+        res.headers_mut().insert(CONTENT_TYPE, TEXT_HTML_UTF8);
+        Ok(res.map(|_| self.0.into()))
+    }
 }

--- a/web/src/handler/types/json.rs
+++ b/web/src/handler/types/json.rs
@@ -12,7 +12,7 @@ use serde::{de::DeserializeOwned, ser::Serialize};
 
 use crate::{
     body::BodyStream,
-    bytes::{BufMutWriter, BytesMut},
+    bytes::{BufMutWriter, Bytes, BytesMut},
     context::WebContext,
     error::{BadRequest, Error},
     handler::{FromRequest, Responder},
@@ -104,9 +104,24 @@ where
 
     #[inline]
     async fn respond(self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+        self._respond(|bytes| ctx.into_response(bytes))
+    }
+
+    #[inline]
+    fn map(self, res: Self::Response) -> Result<Self::Response, Self::Error> {
+        self._respond(|bytes| res.map(|_| bytes.into()))
+    }
+}
+
+impl<T> Json<T> {
+    fn _respond<F, C>(self, func: F) -> Result<WebResponse, Error<C>>
+    where
+        T: Serialize,
+        F: FnOnce(Bytes) -> WebResponse,
+    {
         let mut bytes = BytesMut::new();
         serde_json::to_writer(BufMutWriter(&mut bytes), &self.0)?;
-        let mut res = ctx.into_response(bytes.freeze());
+        let mut res = func(bytes.freeze());
         res.headers_mut().insert(CONTENT_TYPE, JSON);
         Ok(res)
     }

--- a/web/src/handler/types/json.rs
+++ b/web/src/handler/types/json.rs
@@ -103,7 +103,7 @@ where
     type Error = Error<C>;
 
     #[inline]
-    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+    async fn respond(self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         let mut bytes = BytesMut::new();
         serde_json::to_writer(BufMutWriter(&mut bytes), &self.0)?;
         let mut res = ctx.into_response(bytes.freeze());

--- a/web/src/handler/types/vec.rs
+++ b/web/src/handler/types/vec.rs
@@ -36,7 +36,7 @@ impl<'r, C, B> Responder<WebContext<'r, C, B>> for Vec<u8> {
     type Response = WebResponse;
     type Error = Infallible;
 
-    async fn respond_to(self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+    async fn respond(self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         Ok(ctx.into_response(self))
     }
 }

--- a/web/src/handler/types/vec.rs
+++ b/web/src/handler/types/vec.rs
@@ -36,7 +36,12 @@ impl<'r, C, B> Responder<WebContext<'r, C, B>> for Vec<u8> {
     type Response = WebResponse;
     type Error = Infallible;
 
+    #[inline]
     async fn respond(self, ctx: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         Ok(ctx.into_response(self))
+    }
+
+    fn map(self, res: Self::Response) -> Result<Self::Response, Self::Error> {
+        Ok(res.map(|_| self.into()))
     }
 }

--- a/web/src/handler/types/websocket.rs
+++ b/web/src/handler/types/websocket.rs
@@ -174,7 +174,7 @@ where
     type Response = WebResponse;
     type Error = Infallible;
 
-    async fn respond_to(self, _: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
+    async fn respond(self, _: WebContext<'r, C, B>) -> Result<Self::Response, Self::Error> {
         let Self {
             ws,
             ping_interval,


### PR DESCRIPTION
rename `Responder::respond_to` to `Responder::respond`.
add `Responder::map`.
impl `Responder` for tuple types upto 6 items. The first item in tuple would call `Responder::respond` to generate a base response type and following items would call `Responder::map` and mutate it base on their trait method implementations.