### PR TITLE
rework client tls connector.

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -286,7 +286,7 @@ impl Client {
 
         let (stream, version) = self
             .connector
-            .connect(stream, connect.hostname())
+            .call((connect.hostname(), Box::new(stream)))
             .timeout(timer.as_mut())
             .await
             .map_err(|_| TimeoutError::TlsHandshake)??;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -36,7 +36,7 @@ pub use self::connect::Connect;
 pub use self::request::RequestBuilder;
 pub use self::response::Response;
 pub use self::service::{HttpService, Service, ServiceRequest};
-pub use self::tls::{connector::TlsConnect, stream::Io};
+pub use self::tls::{connector::Connector, stream::Io};
 
 // re-export http crate.
 pub use xitca_http::http;


### PR DESCRIPTION
remove `TlsConnect` trait and use `Service` trait for custom tls connector. See `ClientBuilder::tls_connector` for example.