### PR TITLE
import tokio-util for buffered read.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 default = ["http1"]
-http1 = ["httparse", "xitca-http/http1"]
+http1 = ["httparse", "tokio-util", "xitca-http/http1"]
 http2 = ["h2", "itoa", "xitca-http/http2"]
 http3 = ["h3", "h3-quinn", "quinn/tls-rustls", "itoa", "async-stream", "rustls_0dot21", "webpki_roots_0dot25"]
 openssl = ["openssl-crate", "tokio-openssl"]
@@ -31,6 +31,7 @@ tracing = { version = "0.1.40", default-features = false }
 
 # http/1 support
 httparse = { version = "1.8.0", optional = true }
+tokio-util = { version = "0.7", features = ["io"], optional = true }
 
 # http/2 support
 h2 = { version = "0.4", optional = true }

--- a/client/src/h1/body.rs
+++ b/client/src/h1/body.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use futures_core::stream::Stream;
-use tokio::io::{AsyncRead, ReadBuf};
+use tokio::io::AsyncRead;
 use xitca_http::{
     bytes::{Bytes, BytesMut},
     error::BodyError,
@@ -16,20 +16,12 @@ use xitca_http::{
 pub struct ResponseBody<C> {
     conn: C,
     buf: BytesMut,
-    // a chunker reader is used to provide a safe rust only api for reading into buf.
-    // this is less efficient than reading directly into BytesMut.
-    chunk: Vec<u8>,
     decoder: TransferCoding,
 }
 
 impl<C> ResponseBody<C> {
-    pub(crate) fn new(conn: C, buf: BytesMut, chunk: Vec<u8>, decoder: TransferCoding) -> Self {
-        Self {
-            conn,
-            buf,
-            chunk,
-            decoder,
-        }
+    pub(crate) fn new(conn: C, buf: BytesMut, decoder: TransferCoding) -> Self {
+        Self { conn, buf, decoder }
     }
 
     pub(crate) fn conn(&mut self) -> &mut C {
@@ -51,15 +43,14 @@ where
             match this.decoder.decode(&mut this.buf) {
                 ChunkResult::Ok(bytes) => return Poll::Ready(Some(Ok(bytes))),
                 ChunkResult::InsufficientData => {
-                    let mut buf = ReadBuf::new(this.chunk.as_mut_slice());
-                    ready!(Pin::new(&mut *this.conn).poll_read(cx, &mut buf))?;
-                    let filled = buf.filled();
-
-                    if filled.is_empty() {
+                    let n = ready!(tokio_util::io::poll_read_buf(
+                        Pin::new(&mut *this.conn),
+                        cx,
+                        &mut this.buf
+                    ))?;
+                    if n == 0 {
                         return Poll::Ready(Some(Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())));
                     }
-
-                    this.buf.extend_from_slice(filled);
                 }
                 ChunkResult::Err(e) => return Poll::Ready(Some(Err(e.into()))),
                 _ => return Poll::Ready(None),

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -182,12 +182,12 @@ pub(crate) fn base_service() -> HttpService {
 
             #[cfg(feature = "http1")]
             match _res {
-                Ok(Ok((res, buf, chunk, decoder, is_close))) => {
+                Ok(Ok((res, buf, decoder, is_close))) => {
                     if is_close {
                         conn.destroy_on_drop();
                     }
 
-                    let body = crate::h1::body::ResponseBody::new(conn, buf, chunk, decoder);
+                    let body = crate::h1::body::ResponseBody::new(conn, buf, decoder);
                     let res = res.map(|_| crate::body::ResponseBody::H1(body));
                     let timeout = client.timeout_config.response_timeout;
 


### PR DESCRIPTION
Restore behavior of efficient http1 body reading.
