### PR TITLE
add openssl feature.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [features]
 default = ["http1"]
-http1 = ["httparse", "tokio-util", "xitca-http/http1"]
+http1 = ["httparse", "xitca-http/http1"]
 http2 = ["h2", "itoa", "xitca-http/http2"]
 http3 = ["h3", "h3-quinn", "quinn/tls-rustls", "itoa", "async-stream", "rustls_0dot21", "webpki_roots_0dot25"]
-openssl = ["openssl-crate", "tokio-openssl"]
-rustls = ["tokio-rustls", "webpki-roots"]
+openssl = ["xitca-tls/openssl"]
+rustls = ["xitca-tls/rustls", "webpki-roots"]
 compress = ["http-encoding"]
 json = ["serde", "serde_json"]
 websocket = ["http-ws"]
@@ -21,6 +21,7 @@ dangerous = ["rustls_0dot21/dangerous_configuration"]
 
 [dependencies]
 xitca-http = { version = "0.4", default-features = false, features = ["runtime"] }
+xitca-io = { version = "0.2.1" }
 xitca-unsafe-collection = "0.1.1"
 
 futures-core = { version = "0.3.17", default-features = false }
@@ -31,7 +32,6 @@ tracing = { version = "0.1.40", default-features = false }
 
 # http/1 support
 httparse = { version = "1.8.0", optional = true }
-tokio-util = { version = "0.7", features = ["io"], optional = true }
 
 # http/2 support
 h2 = { version = "0.4", optional = true }
@@ -45,12 +45,10 @@ async-stream = { version = "0.3", optional = true }
 # http/2 and http/3 shared
 itoa = { version = "1", optional = true }
 
-# openssl support
-openssl-crate = { package = "openssl", version = "0.10", optional = true }
-tokio-openssl = { version = "0.6.3", optional = true }
+# tls support shared
+xitca-tls = { version = "0.2", optional = true }
 
 # rustls, http3 and dangerous features shared support
-tokio-rustls = { version = "0.26", optional = true }
 webpki-roots = { version = "0.26", optional = true }
 
 # http3 temporary exclusive

--- a/client/src/builder.rs
+++ b/client/src/builder.rs
@@ -15,7 +15,7 @@ use crate::{
     timeout::TimeoutConfig,
     tls::{
         connector::{self, Connector},
-        stream::Io,
+        stream::TlsStream,
     },
 };
 
@@ -189,24 +189,24 @@ impl ClientBuilder {
     ///
     /// # Examples
     /// ```rust
-    /// use xitca_client::{error::Error, http::Version, ClientBuilder, Io, Service};
+    /// use xitca_client::{error::Error, http::Version, ClientBuilder, TlsStream, Service};
     ///
     /// // custom connector type
     /// struct MyConnector;
     ///     
     /// // impl trait for connector.
-    /// impl<'n> Service<(&'n str, Box<dyn Io>)> for MyConnector {
+    /// impl<'n> Service<(&'n str, TlsStream)> for MyConnector {
     ///     // expected output types.
-    ///     type Response = (Box<dyn Io>, Version);
+    ///     type Response = (TlsStream, Version);
     ///     // potential error type.
     ///     type Error = Error;
     ///
     ///     // name is string representation of server name.
     ///     // box io is type erased generic io type. it can be TcpStream, UnixStream, etc.
-    ///     async fn call(&self, (name, io): (&'n str, Box<dyn Io>)) -> Result<Self::Response, Self::Error> {
+    ///     async fn call(&self, (name, io): (&'n str, TlsStream)) -> Result<Self::Response, Self::Error> {
     ///         // tls handshake logic
     ///         // after tls connected must return another type erase io type and according http version of this connection.
-    ///         Ok((Box::new(io), Version::HTTP_11))
+    ///         Ok((io, Version::HTTP_11))
     ///     }
     /// }
     ///
@@ -217,7 +217,7 @@ impl ClientBuilder {
     /// ```
     pub fn tls_connector<T>(mut self, connector: T) -> Self
     where
-        T: for<'n> Service<(&'n str, Box<dyn Io>), Response = (Box<dyn Io>, Version), Error = Error>
+        T: for<'n> Service<(&'n str, TlsStream), Response = (TlsStream, Version), Error = Error>
             + Send
             + Sync
             + 'static,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1,10 +1,8 @@
 use std::{net::SocketAddr, pin::Pin};
 
 use futures_core::stream::Stream;
-use tokio::{
-    net::{TcpSocket, TcpStream},
-    time::{Instant, Sleep},
-};
+use tokio::time::{Instant, Sleep};
+use xitca_io::net::{TcpSocket, TcpStream};
 
 use crate::{
     body::{BodyError, BoxBody},
@@ -302,8 +300,8 @@ impl Client {
                         socket
                     }
                 };
-
-                socket.connect(addr).await.map_err(Into::into)
+                let stream = socket.connect(addr).await?;
+                Ok(TcpStream::from(stream))
             }
             None => TcpStream::connect(addr).await.map_err(Into::into),
         }
@@ -402,7 +400,7 @@ impl Client {
             uri.path_and_query().unwrap().as_str()
         );
 
-        let stream = tokio::net::UnixStream::connect(path)
+        let stream = xitca_io::net::UnixStream::connect(path)
             .timeout(timer.as_mut())
             .await
             .map_err(|_| TimeoutError::Connect)??;

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -121,30 +121,22 @@ impl From<http_ws::ProtocolError> for Error {
 mod _openssl {
     use super::Error;
 
-    use openssl_crate::{error, ssl};
+    use xitca_tls::openssl;
 
-    #[derive(Debug)]
-    pub enum OpensslError {
-        Single(error::Error),
-        Stack(error::ErrorStack),
-        Ssl(ssl::Error),
-    }
+    pub type OpensslError = openssl::ssl::Error;
 
-    impl From<error::Error> for Error {
-        fn from(e: error::Error) -> Self {
-            Self::Openssl(OpensslError::Single(e))
+    impl From<openssl::error::ErrorStack> for Error {
+        fn from(e: openssl::error::ErrorStack) -> Self {
+            Self::Openssl(e.into())
         }
     }
 
-    impl From<error::ErrorStack> for Error {
-        fn from(e: error::ErrorStack) -> Self {
-            Self::Openssl(OpensslError::Stack(e))
-        }
-    }
-
-    impl From<ssl::Error> for Error {
-        fn from(e: ssl::Error) -> Self {
-            Self::Openssl(OpensslError::Ssl(e))
+    impl From<openssl::Error> for Error {
+        fn from(e: openssl::Error) -> Self {
+            match e {
+                openssl::Error::Tls(e) => Self::Openssl(e),
+                openssl::Error::Io(e) => Self::Io(e),
+            }
         }
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -68,7 +68,7 @@ pub use self::request::RequestBuilder;
 pub use self::response::Response;
 pub use self::service::{HttpService, Service, ServiceRequest};
 pub use self::timeout::TimeoutConfig;
-pub use self::tls::{connector::Connector, stream::Io};
+pub use self::tls::{connector::Connector, stream::TlsStream};
 
 // re-export http crate.
 pub use xitca_http::http;

--- a/client/src/tls/connector.rs
+++ b/client/src/tls/connector.rs
@@ -4,23 +4,23 @@ use crate::{
     service::{Service, ServiceDyn},
 };
 
-use super::stream::Io;
+use super::stream::TlsStream;
 
 /// Connector for tls connections.
 ///
 /// All connections are passed to tls connector. Non tls connections would be returned
 /// with a noop pass through.
 pub type Connector =
-    Box<dyn for<'n> ServiceDyn<(&'n str, Box<dyn Io>), Response = (Box<dyn Io>, Version), Error = Error> + Send + Sync>;
+    Box<dyn for<'n> ServiceDyn<(&'n str, TlsStream), Response = (TlsStream, Version), Error = Error> + Send + Sync>;
 
 pub(crate) fn nop() -> Connector {
     struct Nop;
 
-    impl<'n> Service<(&'n str, Box<dyn Io>)> for Nop {
-        type Response = (Box<dyn Io>, Version);
+    impl<'n> Service<(&'n str, TlsStream)> for Nop {
+        type Response = (TlsStream, Version);
         type Error = Error;
 
-        async fn call(&self, (_, _io): (&'n str, Box<dyn Io>)) -> Result<Self::Response, Self::Error> {
+        async fn call(&self, (_, _io): (&'n str, TlsStream)) -> Result<Self::Response, Self::Error> {
             #[cfg(not(feature = "dangerous"))]
             {
                 Err(Error::TlsNotEnabled)
@@ -41,26 +41,24 @@ pub(crate) fn nop() -> Connector {
 
 #[cfg(feature = "openssl")]
 pub(crate) mod openssl {
-    use core::pin::Pin;
-
-    use openssl_crate::ssl::{SslConnector, SslMethod};
-    use tokio_openssl::SslStream;
     use xitca_http::bytes::BufMut;
+    use xitca_tls::openssl::{
+        self,
+        ssl::{SslConnector, SslMethod},
+    };
 
     use super::*;
 
-    impl<'n> Service<(&'n str, Box<dyn Io>)> for SslConnector {
-        type Response = (Box<dyn Io>, Version);
+    impl<'n> Service<(&'n str, TlsStream)> for SslConnector {
+        type Response = (TlsStream, Version);
         type Error = Error;
 
-        async fn call(&self, (name, io): (&'n str, Box<dyn Io>)) -> Result<Self::Response, Self::Error> {
+        async fn call(&self, (name, io): (&'n str, TlsStream)) -> Result<Self::Response, Self::Error> {
             let ssl = self.configure()?.into_ssl(name)?;
-            let mut stream = SslStream::new(ssl, io)?;
-
-            Pin::new(&mut stream).connect().await?;
+            let stream = openssl::TlsStream::connect(ssl, io).await?;
 
             let version = stream
-                .ssl()
+                .session()
                 .selected_alpn_protocol()
                 .map_or(Version::HTTP_11, |version| {
                     if version.windows(2).any(|w| w == b"h2") {
@@ -94,25 +92,29 @@ pub(crate) mod openssl {
 pub(crate) mod rustls {
     use std::sync::Arc;
 
-    use tokio_rustls::{
-        rustls::{pki_types::ServerName, ClientConfig, RootCertStore},
-        TlsConnector,
-    };
     use webpki_roots::TLS_SERVER_ROOTS;
+    use xitca_tls::rustls::{self, pki_types::ServerName, ClientConfig, ClientConnection, RootCertStore};
 
     use super::*;
 
-    impl<'n> Service<(&'n str, Box<dyn Io>)> for TlsConnector {
-        type Response = (Box<dyn Io>, Version);
+    pub struct TlsConnector(Arc<ClientConfig>);
+
+    impl<'n> Service<(&'n str, TlsStream)> for TlsConnector {
+        type Response = (TlsStream, Version);
         type Error = Error;
 
-        async fn call(&self, (name, io): (&'n str, Box<dyn Io>)) -> Result<Self::Response, Self::Error> {
+        async fn call(&self, (name, io): (&'n str, TlsStream)) -> Result<Self::Response, Self::Error> {
             let name = ServerName::try_from(name)
                 .map_err(|_| crate::error::RustlsError::InvalidDnsName)?
                 .to_owned();
-            let stream = self.connect(name, io).await.map_err(crate::error::RustlsError::Io)?;
 
-            let version = stream.get_ref().1.alpn_protocol().map_or(Version::HTTP_11, |version| {
+            let conn = ClientConnection::new(self.0.clone(), name).unwrap();
+
+            let stream = rustls::TlsStream::handshake(io, conn)
+                .await
+                .map_err(crate::error::RustlsError::Io)?;
+
+            let version = stream.session().alpn_protocol().map_or(Version::HTTP_11, |version| {
                 if version.windows(2).any(|w| w == b"h2") {
                     Version::HTTP_2
                 } else {
@@ -135,6 +137,6 @@ pub(crate) mod rustls {
 
         config.alpn_protocols = protocols.iter().map(|p| p.to_vec()).collect();
 
-        Box::new(TlsConnector::from(Arc::new(config)))
+        Box::new(TlsConnector(Arc::new(config)))
     }
 }

--- a/client/src/tls/stream.rs
+++ b/client/src/tls/stream.rs
@@ -1,9 +1,3 @@
-use tokio::io::{AsyncRead, AsyncWrite};
+use xitca_io::io::AsyncIoDyn;
 
-pub type TlsStream = Box<dyn Io>;
-
-/// A trait impl for all types that impl [AsyncRead], [AsyncWrite], [Send] and [Unpin].
-/// Enabling `Box<dyn Io>` trait object usage.
-pub trait Io: AsyncRead + AsyncWrite + Send + Unpin {}
-
-impl<S> Io for S where S: AsyncRead + AsyncWrite + Send + Unpin {}
+pub type TlsStream = Box<dyn AsyncIoDyn + Send + Sync>;

--- a/http/CHANGES.md
+++ b/http/CHANGES.md
@@ -1,4 +1,9 @@
-# unreleased 0.4.0
+# unreleased 0.4.1
+## Change
+- update `xitca-io` to `0.2.1`.
+- update `xitca-tls` to `0.2.1`.
+
+# 0.4.0
 ## Add
 - `util::service::router::PathGen` and `util::service::router::RouteObject` for advanced routing behavior. enabling more complex routing like multiple layer of router nesting. Example:
     ```rust

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -19,7 +19,7 @@ http2 = ["h2", "fnv", "futures-util/alloc", "runtime", "slab"]
 # http3 specific feature.
 http3 = ["xitca-io/http3", "futures-util/alloc", "h3", "h3-quinn", "runtime"]
 # openssl as server side tls.
-openssl = ["dep:openssl", "xitca-tls", "runtime"]
+openssl = ["xitca-tls/openssl", "runtime"]
 # rustls as server side tls.
 rustls = ["xitca-tls/rustls", "runtime"]
 # rustls as server side tls.
@@ -34,7 +34,7 @@ io-uring = ["xitca-io/runtime-uring", "tokio-uring"]
 router = ["xitca-router"]
 
 [dependencies]
-xitca-io = "0.2"
+xitca-io = "0.2.1"
 xitca-service = { version = "0.1", features = ["alloc", "std"] }
 xitca-unsafe-collection = { version = "0.1.1", features = ["bytes"] }
 
@@ -44,14 +44,11 @@ httpdate = "1.0"
 pin-project-lite = "0.2.10"
 tracing = { version = "0.1.40", default-features = false }
 
-# openssl support
-openssl = { version = "0.10", optional = true }
-
 # native tls support
 native-tls = { version = "0.2.7", features = ["alpn"], optional = true }
 
 # tls support shared
-xitca-tls = { version = "0.2.0", optional = true }
+xitca-tls = { version = "0.2.1", optional = true }
 
 # http/1 support
 httparse = { version = "1.8", optional = true }

--- a/http/src/tls/openssl.rs
+++ b/http/src/tls/openssl.rs
@@ -1,40 +1,23 @@
-pub(crate) use openssl::ssl::SslAcceptor as TlsAcceptor;
+pub(crate) use xitca_tls::openssl::ssl::SslAcceptor as TlsAcceptor;
 
-use core::{
-    convert::Infallible,
-    fmt::{self, Debug, Formatter},
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-};
+use core::convert::Infallible;
 
-use std::io;
-
-use openssl::{
-    error::ErrorStack,
-    ssl::{Error, ErrorCode, ShutdownResult, Ssl, SslStream},
-};
-use xitca_io::io::{AsyncIo, Interest, Ready};
+use xitca_io::io::AsyncIo;
 use xitca_service::Service;
+use xitca_tls::openssl::ssl;
 
 use crate::{http::Version, version::AsVersion};
 
 use super::error::TlsError;
 
-/// A wrapper type for [SslStream].
-///
-/// This is to impl new trait for it.
-pub struct TlsStream<Io> {
-    io: SslStream<Io>,
-}
+pub type TlsStream<Io> = xitca_tls::openssl::TlsStream<Io>;
 
 impl<Io> AsVersion for TlsStream<Io>
 where
     Io: AsyncIo,
 {
     fn as_version(&self) -> Version {
-        self.io
-            .ssl()
+        self.session()
             .selected_alpn_protocol()
             .map(Self::from_alpn)
             .unwrap_or(Version::HTTP_11)
@@ -73,22 +56,8 @@ impl TlsAcceptorService {
     #[inline(never)]
     async fn accept<Io: AsyncIo>(&self, io: Io) -> Result<TlsStream<Io>, OpensslError> {
         let ctx = self.acceptor.context();
-        let ssl = Ssl::new(ctx)?;
-        let mut io = SslStream::new(ssl, io)?;
-        let mut interest = Interest::READABLE;
-        loop {
-            io.get_mut().ready(interest).await?;
-            match io.accept() {
-                Ok(_) => return Ok(TlsStream { io }),
-                Err(ref e) if e.code() == ErrorCode::WANT_READ => {
-                    interest = Interest::READABLE;
-                }
-                Err(ref e) if e.code() == ErrorCode::WANT_WRITE => {
-                    interest = Interest::WRITABLE;
-                }
-                Err(e) => return Err(e.into()),
-            }
-        }
+        let ssl = ssl::Ssl::new(ctx)?;
+        TlsStream::accept(ssl, io).await.map_err(Into::into)
     }
 }
 
@@ -101,102 +70,11 @@ impl<Io: AsyncIo> Service<Io> for TlsAcceptorService {
     }
 }
 
-impl<Io: AsyncIo> AsyncIo for TlsStream<Io> {
-    #[inline]
-    fn ready(&self, interest: Interest) -> impl Future<Output = io::Result<Ready>> + Send {
-        self.io.get_ref().ready(interest)
-    }
-
-    #[inline]
-    fn poll_ready(&self, interest: Interest, cx: &mut Context<'_>) -> Poll<io::Result<Ready>> {
-        self.io.get_ref().poll_ready(interest, cx)
-    }
-
-    fn is_vectored_write(&self) -> bool {
-        self.io.get_ref().is_vectored_write()
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let this = self.get_mut();
-        // copied from tokio-openssl crate.
-        match this.io.shutdown() {
-            Ok(ShutdownResult::Sent) | Ok(ShutdownResult::Received) => {}
-            Err(ref e) if e.code() == ErrorCode::ZERO_RETURN => {}
-            Err(ref e) if e.code() == ErrorCode::WANT_READ || e.code() == ErrorCode::WANT_WRITE => {
-                return Poll::Pending;
-            }
-            Err(e) => {
-                return Poll::Ready(Err(e
-                    .into_io_error()
-                    .unwrap_or_else(|e| io::Error::new(io::ErrorKind::Other, e))));
-            }
-        }
-
-        AsyncIo::poll_shutdown(Pin::new(this.io.get_mut()), cx)
-    }
-}
-
-impl<Io: AsyncIo> io::Read for TlsStream<Io> {
-    #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        io::Read::read(&mut self.io, buf)
-    }
-}
-
-impl<Io: AsyncIo> io::Write for TlsStream<Io> {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        io::Write::write(&mut self.io, buf)
-    }
-
-    #[inline]
-    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
-        io::Write::write_vectored(&mut self.io, bufs)
-    }
-
-    #[inline]
-    fn flush(&mut self) -> io::Result<()> {
-        io::Write::flush(&mut self.io)
-    }
-}
-
 /// Collection of 'openssl' error types.
-pub enum OpensslError {
-    Io(io::Error),
-    Tls(Error),
-    Stack(ErrorStack),
-}
-
-impl Debug for OpensslError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Io(ref e) => Debug::fmt(e, f),
-            Self::Tls(ref e) => Debug::fmt(e, f),
-            Self::Stack(ref e) => Debug::fmt(e, f),
-        }
-    }
-}
-
-impl From<io::Error> for OpensslError {
-    fn from(e: io::Error) -> Self {
-        Self::Io(e)
-    }
-}
-
-impl From<ErrorStack> for OpensslError {
-    fn from(e: ErrorStack) -> Self {
-        Self::Stack(e)
-    }
-}
-
-impl From<Error> for OpensslError {
-    fn from(e: Error) -> Self {
-        Self::Tls(e)
-    }
-}
+pub type OpensslError = xitca_tls::openssl::Error;
 
 impl From<OpensslError> for TlsError {
     fn from(e: OpensslError) -> Self {
-        Self::Openssl(e)
+        TlsError::Openssl(e)
     }
 }

--- a/io/src/net/tcp.rs
+++ b/io/src/net/tcp.rs
@@ -30,6 +30,12 @@ impl TcpStream {
     }
 }
 
+impl From<tokio::net::TcpStream> for TcpStream {
+    fn from(stream: tokio::net::TcpStream) -> Self {
+        Self(stream)
+    }
+}
+
 impl TryFrom<Stream> for TcpStream {
     type Error = io::Error;
 

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -15,7 +15,7 @@ quic = ["quinn", "quinn-proto", "rustls-pemfile", "rustls_0dot21"]
 io-uring = ["xitca-io/runtime-uring"]
 
 [dependencies]
-xitca-io = { version = "0.2", features = ["runtime"] }
+xitca-io = { version = "0.2.1", features = ["runtime"] }
 xitca-service = "0.1"
 xitca-unsafe-collection = { version = "0.1", features = ["bytes"] }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,7 +16,7 @@ http3 = ["xitca-io/http3"]
 io-uring = ["tokio-uring"]
 
 [dependencies]
-xitca-io = { version = "0.2", features = ["runtime"] }
+xitca-io = { version = "0.2.1", features = ["runtime"] }
 xitca-service = { version = "0.1", features = ["alloc"] }
 xitca-unsafe-collection = "0.1"
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -10,7 +10,7 @@ io-uring = ["xitca-http/io-uring", "xitca-server/io-uring"]
 xitca-client = { version = "0.1", features = ["http2", "http3", "websocket", "dangerous"] }
 xitca-http = { version = "0.4", features = ["http2", "http3"] }
 xitca-codegen = "0.1"
-xitca-io = "0.2"
+xitca-io = "0.2.1"
 xitca-server = { version = "0.2", features = ["http3"] }
 xitca-service = "0.1"
 xitca-unsafe-collection = "0.1.1"

--- a/tls/CHANGES.md
+++ b/tls/CHANGES.md
@@ -1,4 +1,6 @@
-# unreleased
+# unreleased 0.2.1
+## Add
+- `openssl` feature
 
 # 0.2.0
 ## Change

--- a/tls/Cargo.toml
+++ b/tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xitca-tls"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "tls utility for xitca"
@@ -10,10 +10,12 @@ authors = ["fakeshadow <everestshadow@gmail.com>"]
 readme= "README.md"
 
 [features]
+openssl = ["dep:openssl"]
 rustls = ["dep:rustls"]
 rustls-uring = ["rustls", "xitca-io/runtime-uring"]
 
 [dependencies]
-xitca-io = { version = "0.2", features = ["runtime"] }
+xitca-io = { version = "0.2.1", features = ["runtime"] }
 
 rustls = { version = "0.23", optional = true }
+openssl = { version = "0.10", optional = true }

--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "openssl")]
+pub mod openssl;
 #[cfg(feature = "rustls")]
 pub mod rustls;
 #[cfg(feature = "rustls-uring")]

--- a/tls/src/openssl.rs
+++ b/tls/src/openssl.rs
@@ -1,0 +1,140 @@
+use core::{
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use std::io;
+
+pub use openssl::*;
+
+use openssl::ssl::{ErrorCode, ShutdownResult, Ssl, SslRef, SslStream};
+use xitca_io::io::{AsyncIo, Interest, Ready};
+
+/// A stream managed by `openssl` crate for tls read/write.
+pub struct TlsStream<Io> {
+    io: SslStream<Io>,
+}
+
+impl<Io> TlsStream<Io>
+where
+    Io: AsyncIo,
+{
+    /// acquire a reference to the session type.
+    pub fn session(&self) -> &SslRef {
+        self.io.ssl()
+    }
+
+    pub async fn accept(ssl: Ssl, io: Io) -> Result<Self, Error> {
+        Self::connect_or_accept(ssl, io, |io| io.accept()).await
+    }
+
+    pub async fn connect(ssl: Ssl, io: Io) -> Result<Self, Error> {
+        Self::connect_or_accept(ssl, io, |io| io.connect()).await
+    }
+
+    async fn connect_or_accept<F>(ssl: Ssl, io: Io, mut func: F) -> Result<Self, Error>
+    where
+        F: FnMut(&mut SslStream<Io>) -> Result<(), openssl::ssl::Error>,
+    {
+        let mut io = SslStream::new(ssl, io)?;
+        let mut interest = Interest::READABLE | Interest::WRITABLE;
+        loop {
+            io.get_mut().ready(interest).await.map_err(Error::Io)?;
+            match func(&mut io) {
+                Ok(_) => return Ok(TlsStream { io }),
+                Err(ref e) if e.code() == ErrorCode::WANT_READ => {
+                    interest = Interest::READABLE;
+                }
+                Err(ref e) if e.code() == ErrorCode::WANT_WRITE => {
+                    interest = Interest::WRITABLE;
+                }
+                Err(e) => return Err(Error::Tls(e)),
+            }
+        }
+    }
+}
+
+impl<Io: AsyncIo> AsyncIo for TlsStream<Io> {
+    #[inline]
+    fn ready(&self, interest: Interest) -> impl Future<Output = io::Result<Ready>> + Send {
+        self.io.get_ref().ready(interest)
+    }
+
+    #[inline]
+    fn poll_ready(&self, interest: Interest, cx: &mut Context<'_>) -> Poll<io::Result<Ready>> {
+        self.io.get_ref().poll_ready(interest, cx)
+    }
+
+    fn is_vectored_write(&self) -> bool {
+        self.io.get_ref().is_vectored_write()
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        // copied from tokio-openssl crate.
+        match this.io.shutdown() {
+            Ok(ShutdownResult::Sent) | Ok(ShutdownResult::Received) => {}
+            Err(ref e) if e.code() == ErrorCode::ZERO_RETURN => {}
+            Err(ref e) if e.code() == ErrorCode::WANT_READ || e.code() == ErrorCode::WANT_WRITE => {
+                return Poll::Pending;
+            }
+            Err(e) => {
+                return Poll::Ready(Err(e
+                    .into_io_error()
+                    .unwrap_or_else(|e| io::Error::new(io::ErrorKind::Other, e))));
+            }
+        }
+
+        AsyncIo::poll_shutdown(Pin::new(this.io.get_mut()), cx)
+    }
+}
+
+impl<Io: AsyncIo> io::Read for TlsStream<Io> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        io::Read::read(&mut self.io, buf)
+    }
+}
+
+impl<Io: AsyncIo> io::Write for TlsStream<Io> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        io::Write::write(&mut self.io, buf)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        io::Write::write_vectored(&mut self.io, bufs)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        io::Write::flush(&mut self.io)
+    }
+}
+
+/// Collection of 'openssl' error types.
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    Tls(openssl::ssl::Error),
+}
+
+impl From<openssl::error::ErrorStack> for Error {
+    fn from(e: openssl::error::ErrorStack) -> Self {
+        Self::Tls(e.into())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(ref e) => fmt::Display::fmt(e, f),
+            Self::Tls(ref e) => fmt::Display::fmt(e, f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/tls/src/rustls.rs
+++ b/tls/src/rustls.rs
@@ -52,6 +52,10 @@ where
     S: SideData,
     Io: AsyncIo,
 {
+    /// acquire a reference to the session type. Typically either [ClientConnection] or [ServerConnection]
+    ///
+    /// [ClientConnection]: rustls::ClientConnection
+    /// [ServerConnection]: rustls::ServerConnection
     pub fn session(&self) -> &C {
         &self.conn
     }


### PR DESCRIPTION
rework `xitca-client` and `xitca-http` to depend on `xitca-tls` for `rustls` and `opeensl` crate support.