### PR TITLE
make request methods infallible.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -75,7 +75,7 @@ serde = { version = "1.0.130", default-features = false, optional = true }
 serde_json = { version = "1", optional = true }
 
 # websocket
-http-ws = { version = "0.3", features = ["stream"], optional = true }
+http-ws = { version = "0.4", features = ["stream"], optional = true }
 
 [dev-dependencies]
 futures = "0.3"

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -55,6 +55,28 @@ impl From<Infallible> for Error {
     }
 }
 
+/// a collection of multiple errors chained together.
+#[derive(Debug)]
+pub struct ErrorMultiple(Vec<Error>);
+
+impl fmt::Display for ErrorMultiple {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for e in self.0.iter() {
+            write!(f, "{}", e)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl error::Error for ErrorMultiple {}
+
+impl From<Vec<Error>> for Error {
+    fn from(err: Vec<Error>) -> Self {
+        Self::Std(Box::new(ErrorMultiple(err)))
+    }
+}
+
 #[derive(Debug)]
 pub enum InvalidUri {
     MissingHost,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -9,7 +9,7 @@
 //!     // build client with tls enabled.
 //!     let client = Client::builder().rustls().finish();
 //!     // send get request to google and wait for response.
-//!     let res = client.get("https://www.google.com/")?.send().await?;
+//!     let res = client.get("https://www.google.com/").send().await?;
 //!     // parse streaming response body to bytes.
 //!     let body = res.body().await?;
 //!     // print the body as lossy string.

--- a/http-ws/CHANGES.md
+++ b/http-ws/CHANGES.md
@@ -1,4 +1,6 @@
-# unreleased
+# unreleased 0.4.0
+## Change
+- `client_request_from_uri` becomes infallible by receive `Uri` type without try conversion.
 
 # 0.3.0
 ## Add

--- a/http-ws/Cargo.toml
+++ b/http-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-ws"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "websocket for http crate type"

--- a/http-ws/src/lib.rs
+++ b/http-ws/src/lib.rs
@@ -86,12 +86,7 @@ impl From<HandshakeError> for Builder {
 /// Prepare a [Request] with given [Uri] and [Version]  for websocket connection.
 /// Only [Version::HTTP_11] and [Version::HTTP_2] are supported.
 /// After process the request would be ready to be sent to server.
-pub fn client_request_from_uri<U, E>(uri: U, version: Version) -> Result<Request<()>, E>
-where
-    Uri: TryFrom<U, Error = E>,
-{
-    let uri = uri.try_into()?;
-
+pub fn client_request_from_uri(uri: Uri, version: Version) -> Request<()> {
     let mut req = Request::new(());
     *req.uri_mut() = uri;
     *req.version_mut() = version;
@@ -124,7 +119,7 @@ where
     req.headers_mut()
         .insert(SEC_WEBSOCKET_VERSION, SEC_WEBSOCKET_VERSION_VALUE);
 
-    Ok(req)
+    req
 }
 
 /// Verify HTTP/1.1 WebSocket handshake request and create handshake response.

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -16,7 +16,7 @@ xitca-service = "0.1"
 xitca-unsafe-collection = "0.1.1"
 xitca-web = "0.5"
 
-http-ws = { version = "0.3", features = ["stream"] }
+http-ws = { version = "0.4", features = ["stream"] }
 
 async-stream = "0.3"
 futures-util = "0.3.17"

--- a/test/tests/h1.rs
+++ b/test/tests/h1.rs
@@ -27,7 +27,7 @@ async fn h1_get() -> Result<(), Error> {
     let c = Client::new();
 
     for _ in 0..3 {
-        let mut res = c.get(&server_url)?.version(Version::HTTP_11).send().await?;
+        let mut res = c.get(&server_url).version(Version::HTTP_11).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let body = res.string().await?;
@@ -50,7 +50,7 @@ async fn h1_head() -> Result<(), Error> {
     let c = Client::new();
 
     for _ in 0..3 {
-        let mut res = c.head(&server_url)?.version(Version::HTTP_11).send().await?;
+        let mut res = c.head(&server_url).version(Version::HTTP_11).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let body = res.string().await?;
@@ -79,7 +79,7 @@ async fn h1_post() -> Result<(), Error> {
         }
         let body_len = body.len();
 
-        let mut res = c.post(&server_url)?.version(Version::HTTP_11).text(body).send().await?;
+        let mut res = c.post(&server_url).version(Version::HTTP_11).text(body).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let body = res.limit::<{ 12 * 1024 }>().string().await?;
@@ -107,7 +107,7 @@ async fn h1_drop_body_read() -> Result<(), Error> {
             body.extend_from_slice(b"Hello,World!");
         }
 
-        let mut res = c.post(&server_url)?.version(Version::HTTP_11).text(body).send().await?;
+        let mut res = c.post(&server_url).version(Version::HTTP_11).text(body).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(res.can_close_connection());
     }
@@ -133,7 +133,7 @@ async fn h1_partial_body_read() -> Result<(), Error> {
             body.extend_from_slice(b"Hello,World!");
         }
 
-        let mut res = c.post(&server_url)?.version(Version::HTTP_11).text(body).send().await?;
+        let mut res = c.post(&server_url).version(Version::HTTP_11).text(body).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(res.can_close_connection());
     }
@@ -153,7 +153,7 @@ async fn h1_close_connection() -> Result<(), Error> {
 
     let c = Client::new();
 
-    let mut res = c.get(&server_url)?.version(Version::HTTP_11).send().await?;
+    let mut res = c.get(&server_url).version(Version::HTTP_11).send().await?;
     assert_eq!(res.status().as_u16(), 200);
     assert!(res.can_close_connection());
 
@@ -174,7 +174,7 @@ async fn h1_request_too_large() -> Result<(), Error> {
 
     let c = Client::new();
 
-    let mut req = c.get(&server_url)?.version(Version::HTTP_11);
+    let mut req = c.get(&server_url).version(Version::HTTP_11);
 
     let body = vec![*b"H".first().unwrap(); 512 * 1024];
     req.headers_mut()
@@ -184,7 +184,7 @@ async fn h1_request_too_large() -> Result<(), Error> {
     assert_eq!(res.status().as_u16(), 200);
     let _ = res.body().await;
 
-    let mut req = c.get(&server_url)?.version(Version::HTTP_11);
+    let mut req = c.get(&server_url).version(Version::HTTP_11);
 
     let body = vec![*b"H".first().unwrap(); 1024 * 1024];
     req.headers_mut()

--- a/test/tests/h2.rs
+++ b/test/tests/h2.rs
@@ -20,7 +20,7 @@ async fn h2_get() -> Result<(), Error> {
     let c = Client::new();
 
     for _ in 0..3 {
-        let mut res = c.get(&server_url)?.version(Version::HTTP_2).send().await?;
+        let mut res = c.get(&server_url).version(Version::HTTP_2).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let body = res.string().await?;
@@ -47,7 +47,7 @@ async fn h2_post() -> Result<(), Error> {
         for _ in 0..1024 * 1024 {
             body.extend_from_slice(b"Hello,World!");
         }
-        let mut res = c.post(&server_url)?.version(Version::HTTP_2).text(body).send().await?;
+        let mut res = c.post(&server_url).version(Version::HTTP_2).text(body).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let _ = res.body().await;
@@ -69,7 +69,7 @@ async fn h2_connect() -> Result<(), Error> {
     let c = Client::new();
 
     let mut tunnel = c
-        .connect(&server_url)?
+        .connect(&server_url)
         .version(Version::HTTP_2)
         .send()
         .await?
@@ -117,7 +117,7 @@ async fn h2_keepalive() -> Result<(), Error> {
             .block_on(async move {
                 let c = Client::new();
 
-                let mut res = c.get(&server_url)?.version(Version::HTTP_2).send().await?;
+                let mut res = c.get(&server_url).version(Version::HTTP_2).send().await?;
                 assert_eq!(res.status().as_u16(), 200);
                 assert!(!res.can_close_connection());
                 let body = res.string().await?;

--- a/test/tests/h2_v2.rs
+++ b/test/tests/h2_v2.rs
@@ -57,7 +57,7 @@ async fn h2_v2_post() {
 
     let c = Client::new();
 
-    let mut req = c.post("https://localhost:8080/").unwrap();
+    let mut req = c.post("https://localhost:8080/");
 
     req.headers_mut().insert("foo", "bar".parse().unwrap());
 

--- a/test/tests/h3.rs
+++ b/test/tests/h3.rs
@@ -17,7 +17,7 @@ async fn h3_get() -> Result<(), Error> {
     let server_url = format!("https://localhost:{}/", handle.addr().port());
 
     for _ in 0..3 {
-        let mut res = c.get(&server_url)?.version(Version::HTTP_3).send().await?;
+        let mut res = c.get(&server_url).version(Version::HTTP_3).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let body = res.string().await?;
@@ -44,7 +44,7 @@ async fn h3_post() -> Result<(), Error> {
         for _ in 0..1024 * 1024 {
             body.extend_from_slice(b"Hello,World!");
         }
-        let mut res = c.post(&server_url)?.version(Version::HTTP_3).text(body).send().await?;
+        let mut res = c.post(&server_url).version(Version::HTTP_3).text(body).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
     }

--- a/test/tests/websocket.rs
+++ b/test/tests/websocket.rs
@@ -12,7 +12,7 @@ async fn message() -> Result<(), Error> {
 
     let c = Client::new();
 
-    let ws = c.ws(&format!("ws://{}", handle.ip_port_string()))?.send().await?;
+    let ws = c.ws(&format!("ws://{}", handle.ip_port_string())).send().await?;
 
     let (mut tx, mut rx) = ws.split();
 
@@ -45,7 +45,7 @@ async fn message_h2() -> Result<(), Error> {
 
     {
         let c = Client::new();
-        let (mut tx, mut rx) = c.ws2(&server_url)?.send().await?.split();
+        let (mut tx, mut rx) = c.ws2(&server_url).send().await?.split();
 
         for _ in 0..9 {
             tx.send(Message::Text(Bytes::from("Hello,World!"))).await?;


### PR DESCRIPTION
Majority of `Client`'s request api would not fail in place and error handling is delayed until `RequestBuilder::send` is called.