### PR TITLE
update xitca-client dep. dedup of RequestBuilder types.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -30,7 +30,7 @@ websocket = ["http-ws"]
 dangerous = []
 
 [dependencies]
-xitca-http = { version = "0.6.0", default-features = false, features = ["runtime"] }
+xitca-http = { version = "0.7.0", default-features = false, features = ["runtime"] }
 xitca-io = "0.4.0"
 xitca-unsafe-collection = "0.2.0"
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -180,7 +180,7 @@ impl Client {
         uri::Uri: TryFrom<U>,
         Error: From<<uri::Uri as TryFrom<U>>::Error>,
     {
-        HttpTunnelRequest::new(self.get(url).method(Method::CONNECT))
+        self.get(url).method(Method::CONNECT).mutate_marker()
     }
 
     #[cfg(all(feature = "websocket", feature = "http1"))]
@@ -247,18 +247,17 @@ impl Client {
         uri::Uri: TryFrom<U>,
         Error: From<<uri::Uri as TryFrom<U>>::Error>,
     {
-        let builder = match uri::Uri::try_from(url) {
+        match uri::Uri::try_from(url) {
             Ok(uri) => {
                 let req = http_ws::client_request_from_uri(uri, version).map(|_| BoxBody::default());
-                self.request(req)
+                self.request(req).mutate_marker()
             }
             Err(e) => {
-                let mut builder = self.request(http::Request::new(BoxBody::default()));
+                let mut builder = RequestBuilder::new(http::Request::new(BoxBody::default()), self);
                 builder.push_error(e.into());
                 builder
             }
-        };
-        crate::ws::WsRequest::new(builder)
+        }
     }
 }
 

--- a/client/src/http_tunnel.rs
+++ b/client/src/http_tunnel.rs
@@ -17,10 +17,11 @@ use super::{
     connection::ConnectionExclusive,
     error::{Error, ErrorResponse},
     http::StatusCode,
-    tunnel::{Leak, Tunnel, TunnelRequest},
+    request::RequestBuilder,
+    tunnel::{Leak, Tunnel},
 };
 
-pub type HttpTunnelRequest<'a> = TunnelRequest<'a, marker::Connect>;
+pub type HttpTunnelRequest<'a> = RequestBuilder<'a, marker::Connect>;
 
 mod marker {
     pub struct Connect;
@@ -29,7 +30,7 @@ mod marker {
 impl<'a> HttpTunnelRequest<'a> {
     /// Send the request and wait for response asynchronously.
     pub async fn send(self) -> Result<Tunnel<HttpTunnel<'a>>, Error> {
-        let res = self.req.send().await?;
+        let res = self._send().await?;
 
         let status = res.status();
         let expect_status = StatusCode::OK;

--- a/client/src/tunnel.rs
+++ b/client/src/tunnel.rs
@@ -1,76 +1,12 @@
 use core::{
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
     pin::Pin,
     task::{Context, Poll},
-    time::Duration,
 };
 
 use std::sync::Mutex;
 
 use futures_core::stream::Stream;
 use futures_sink::Sink;
-
-use super::{
-    http::{Method, Version},
-    request::RequestBuilder,
-};
-
-/// new type of [RequestBuilder] with extended functionality for tunnel handling.
-pub struct TunnelRequest<'a, M> {
-    pub(crate) req: RequestBuilder<'a>,
-    _marker: PhantomData<M>,
-}
-
-/// new type of [RequestBuilder] with extended functionality for tunnel handling.
-
-impl<'a, M> Deref for TunnelRequest<'a, M> {
-    type Target = RequestBuilder<'a>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.req
-    }
-}
-
-impl<'a, M> DerefMut for TunnelRequest<'a, M> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.req
-    }
-}
-
-impl<'a, M> TunnelRequest<'a, M> {
-    pub(super) fn new(req: RequestBuilder<'a>) -> Self {
-        Self {
-            req,
-            _marker: PhantomData,
-        }
-    }
-
-    /// Set HTTP method of this request.
-    pub fn method(mut self, method: Method) -> Self {
-        self.req = self.req.method(method);
-        self
-    }
-
-    #[doc(hidden)]
-    /// Set HTTP version of this request.
-    ///
-    /// By default request's HTTP version depends on network stream
-    pub fn version(mut self, version: Version) -> Self {
-        self.req = self.req.version(version);
-        self
-    }
-
-    /// Set timeout of this request.
-    ///
-    /// The value passed would override global [ClientBuilder::set_request_timeout].
-    ///
-    /// [ClientBuilder::set_request_timeout]: crate::ClientBuilder::set_request_timeout
-    pub fn timeout(mut self, dur: Duration) -> Self {
-        self.req = self.req.timeout(dur);
-        self
-    }
-}
 
 /// sender part of tunneled connection.
 /// [Sink] trait is used to asynchronously send message.

--- a/client/src/ws.rs
+++ b/client/src/ws.rs
@@ -18,17 +18,18 @@ use super::{
     connection::ConnectionExclusive,
     error::{Error, ErrorResponse},
     http::{StatusCode, Version},
-    tunnel::{Leak, Tunnel, TunnelRequest, TunnelSink, TunnelStream},
+    request::RequestBuilder,
+    tunnel::{Leak, Tunnel, TunnelSink, TunnelStream},
 };
-
-mod marker {
-    pub struct WebSocket;
-}
 
 /// new type of [RequestBuilder] with extended functionality for websocket handling.
 ///
 /// [RequestBuilder]: crate::RequestBuilder
-pub type WsRequest<'a> = TunnelRequest<'a, marker::WebSocket>;
+pub type WsRequest<'a> = RequestBuilder<'a, marker::WebSocket>;
+
+mod marker {
+    pub struct WebSocket;
+}
 
 /// A unified websocket that can be used as both sender/receiver.
 ///
@@ -46,7 +47,7 @@ pub type WebSocketReader<'a, 'b> = TunnelStream<'a, WebSocketTunnel<'b>>;
 impl<'a> WsRequest<'a> {
     /// Send the request and wait for response asynchronously.
     pub async fn send(self) -> Result<WebSocket<'a>, Error> {
-        let res = self.req.send().await?;
+        let res = self._send().await?;
 
         let status = res.status();
         let expect_status = match res.version() {

--- a/client/src/ws.rs
+++ b/client/src/ws.rs
@@ -108,18 +108,13 @@ impl Leak for WebSocketTunnel<'_> {
 impl Sink<Message> for WebSocketTunnel<'_> {
     type Error = Error;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // TODO: set up a meaningful backpressure limit for send buf.
-        if !self.as_mut().get_mut().send_buf.chunk().is_empty() {
-            self.poll_flush(cx)
-        } else {
-            Poll::Ready(Ok(()))
-        }
+        Poll::Ready(Ok(()))
     }
 
     fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
         let inner = self.get_mut();
-
         inner.codec.encode(item, &mut inner.send_buf).map_err(Into::into)
     }
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -8,18 +8,18 @@ io-uring = ["xitca-http/io-uring", "xitca-server/io-uring"]
 
 [dependencies]
 xitca-client = { version = "0.1", features = ["http2", "http3", "websocket", "dangerous"] }
-xitca-http = { version = "0.6", features = ["http2", "http3"] }
-xitca-codegen = "0.2"
-xitca-io = "0.4.0"
-xitca-server = { version = "0.4", features = ["quic"] }
-xitca-service = "0.2.0"
+xitca-http = { version = "0.7", features = ["http2", "http3"] }
+xitca-codegen = "0.3"
+xitca-io = "0.4.1"
+xitca-server = { version = "0.5", features = ["quic"] }
+xitca-service = "0.3.0"
 xitca-unsafe-collection = "0.2"
-xitca-web = "0.6"
+xitca-web = "0.7"
 
 http-ws = { version = "0.4", features = ["stream"] }
 
 async-stream = "0.3"
 futures-util = "0.3.17"
-h3-quinn = "0.0.6"
+h3-quinn = "0.0.7"
 rustls-pemfile = "2"
 tokio = { version = "1.30", features = ["macros", "rt"] }

--- a/test/tests/macro.rs
+++ b/test/tests/macro.rs
@@ -97,7 +97,7 @@ struct MyState {
 
 #[test]
 fn state_borrow() {
-    use core::borrow::Borrow;
+    use xitca_web::handler::state::BorrowState;
 
     let state = MyState {
         field1: String::from("996"),


### PR DESCRIPTION
update `xitca-client` to use unreleased version of `xitca-http` 0.7.
remove `TunnelRequest` type and related type alias will point to `RequestBuilder`.