### PR TITLE
refactor encoding functions

### DIFF
--- a/postgres/src/cancel.rs
+++ b/postgres/src/cancel.rs
@@ -3,15 +3,7 @@
 use postgres_protocol::message::frontend;
 use xitca_io::bytes::BytesMut;
 
-use super::{client::Client, error::Error, session::Session};
-
-impl Client {
-    /// Constructs a cancellation token that can later be used to request cancellation of a query running on the
-    /// connection associated with this client.
-    pub fn cancel_token(&self) -> Session {
-        self.session.clone()
-    }
-}
+use super::{error::Error, session::Session};
 
 impl Session {
     /// Attempts to cancel the in-progress query on the connection associated with Self.

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -15,7 +15,7 @@ use super::{
     session::Session,
     statement::Statement,
     transaction::Transaction,
-    ToSql,
+    types::ToSql,
 };
 
 pub struct Client {

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -2,7 +2,6 @@ use core::future::Future;
 
 use std::{collections::HashMap, sync::Mutex};
 
-use postgres_protocol::message::frontend;
 use postgres_types::{Oid, Type};
 use xitca_io::bytes::BytesMut;
 use xitca_unsafe_collection::no_hash::NoHashBuilder;
@@ -152,6 +151,12 @@ impl Client {
         CopyOut::new(&mut &*self, stmt).await
     }
 
+    /// Constructs a cancellation token that can later be used to request cancellation of a query running on the
+    /// connection associated with this client.
+    pub fn cancel_token(&self) -> Session {
+        self.session.clone()
+    }
+
     /// a lossy hint of running state of io driver. an io driver shutdown can happen
     /// at the same time this api is called.
     pub fn closed(&self) -> bool {
@@ -219,7 +224,7 @@ impl Query for &Client {
     where
         I: AsParams,
     {
-        send_encode(self, stmt, params)
+        encode::send_encode(self, stmt, params)
     }
 }
 
@@ -229,33 +234,22 @@ impl Query for Client {
     where
         I: AsParams,
     {
-        send_encode(self, stmt, params)
+        encode::send_encode(self, stmt, params)
     }
-}
-
-fn send_encode<I>(cli: &Client, stmt: &Statement, params: I) -> Result<Response, Error>
-where
-    I: AsParams,
-{
-    cli.tx.send(|buf| encode::encode(buf, stmt, params.into_iter()))
 }
 
 impl QuerySimple for Client {
     #[inline]
     fn _send_encode_simple(&mut self, stmt: &str) -> Result<Response, Error> {
-        send_encode_simple(self, stmt)
+        encode::send_encode_simple(self, stmt)
     }
 }
 
 impl QuerySimple for &Client {
     #[inline]
     fn _send_encode_simple(&mut self, stmt: &str) -> Result<Response, Error> {
-        send_encode_simple(self, stmt)
+        encode::send_encode_simple(self, stmt)
     }
-}
-
-fn send_encode_simple(cli: &Client, stmt: &str) -> Result<Response, Error> {
-    cli.tx.send(|buf| frontend::query(stmt, buf).map_err(Into::into))
 }
 
 impl r#Copy for Client {

--- a/postgres/src/column.rs
+++ b/postgres/src/column.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use super::Type;
+use super::types::Type;
 
 /// Information about a column of a query.
 #[derive(Clone)]

--- a/postgres/src/driver.rs
+++ b/postgres/src/driver.rs
@@ -212,10 +212,13 @@ impl AsyncLendingIterator for Driver {
 }
 
 impl IntoFuture for Driver {
-    type Output = ();
+    type Output = Result<(), Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(mut self) -> Self::IntoFuture {
-        Box::pin(async move { while self.try_next().await.ok().flatten().is_some() {} })
+        Box::pin(async move {
+            while self.try_next().await?.is_some() {}
+            Ok(())
+        })
     }
 }

--- a/postgres/src/from_sql.rs
+++ b/postgres/src/from_sql.rs
@@ -3,7 +3,7 @@ use core::ops::Range;
 use xitca_io::bytes::Bytes;
 use xitca_unsafe_collection::bytes::BytesStr;
 
-use super::{FromSql, Type};
+use super::types::{FromSql, Type};
 
 pub type FromSqlError = Box<dyn std::error::Error + Sync + Send>;
 

--- a/postgres/src/iter.rs
+++ b/postgres/src/iter.rs
@@ -1,6 +1,6 @@
 use core::future::Future;
 
-use super::ToSql;
+use super::types::ToSql;
 
 /// async streaming iterator with borrowed Item from Self.
 pub trait AsyncLendingIterator {

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -38,13 +38,12 @@ pub mod pipeline;
 pub mod pool;
 pub mod row;
 pub mod statement;
+pub mod types;
 
 #[cfg(feature = "quic")]
 pub mod proxy;
 #[cfg(feature = "quic")]
 pub use driver::quic::QuicStream;
-
-pub use postgres_types::{BorrowToSql, FromSql, ToSql, Type};
 
 pub use self::{
     client::Client,

--- a/postgres/src/pipeline.rs
+++ b/postgres/src/pipeline.rs
@@ -22,7 +22,7 @@ use super::{
     query::AsParams,
     row::Row,
     statement::Statement,
-    ToSql,
+    types::ToSql,
 };
 
 /// A pipelined sql query type. It lazily batch queries into local buffer and try to send it

--- a/postgres/src/pool.rs
+++ b/postgres/src/pool.rs
@@ -20,7 +20,8 @@ use super::{
     session::Session,
     statement::Statement,
     transaction::Transaction,
-    BoxedFuture, Postgres, ToSql, Type,
+    types::{ToSql, Type},
+    BoxedFuture, Postgres,
 };
 
 /// builder type for connection pool

--- a/postgres/src/prepare.rs
+++ b/postgres/src/prepare.rs
@@ -5,14 +5,15 @@ use postgres_protocol::message::{backend, frontend};
 use postgres_types::{Field, Kind, Oid};
 use tracing::debug;
 
-use crate::{
+use super::{
     client::Client,
     column::Column,
     driver::codec::Response,
     error::Error,
     iter::AsyncLendingIterator,
     statement::{Statement, StatementGuarded},
-    BoxedFuture, Type,
+    types::Type,
+    BoxedFuture,
 };
 
 impl Client {

--- a/postgres/src/query.rs
+++ b/postgres/src/query.rs
@@ -7,7 +7,7 @@ pub(crate) mod encode;
 pub use base::{Query, RowStream};
 pub use simple::{QuerySimple, RowSimpleStream};
 
-use super::BorrowToSql;
+use super::types::BorrowToSql;
 
 /// super trait to constraint Self and associated types' trait bounds.
 pub trait AsParams: IntoIterator<IntoIter: ExactSizeIterator, Item: BorrowToSql> {}

--- a/postgres/src/query/base.rs
+++ b/postgres/src/query/base.rs
@@ -10,7 +10,7 @@ use crate::{
     query::AsParams,
     row::Row,
     statement::Statement,
-    ToSql,
+    types::ToSql,
 };
 
 use super::row_stream::GenericRowStream;

--- a/postgres/src/query/simple.rs
+++ b/postgres/src/query/simple.rs
@@ -7,7 +7,9 @@ use core::{
 use fallible_iterator::FallibleIterator;
 use postgres_protocol::message::backend;
 
-use crate::{column::Column, driver::codec::Response, error::Error, iter::AsyncLendingIterator, row::RowSimple, Type};
+use crate::{
+    column::Column, driver::codec::Response, error::Error, iter::AsyncLendingIterator, row::RowSimple, types::Type,
+};
 
 use super::row_stream::GenericRowStream;
 

--- a/postgres/src/row/traits.rs
+++ b/postgres/src/row/traits.rs
@@ -1,4 +1,4 @@
-use crate::{column::Column, Type};
+use crate::{column::Column, types::Type};
 
 mod sealed {
     pub trait Sealed {}

--- a/postgres/src/row/types.rs
+++ b/postgres/src/row/types.rs
@@ -9,7 +9,7 @@ use crate::{
     column::Column,
     error::{Error, InvalidColumnIndex, WrongType},
     from_sql::FromSqlExt,
-    Type,
+    types::Type,
 };
 
 use super::traits::RowIndexAndType;

--- a/postgres/src/statement.rs
+++ b/postgres/src/statement.rs
@@ -4,7 +4,7 @@ use core::ops::Deref;
 
 use postgres_protocol::message::frontend;
 
-use super::{client::Client, column::Column, Type};
+use super::{client::Client, column::Column, types::Type};
 
 /// Guarded statement that would cancel itself when dropped.
 pub struct StatementGuarded<C>

--- a/postgres/src/transaction.rs
+++ b/postgres/src/transaction.rs
@@ -2,7 +2,7 @@ use super::{
     error::Error,
     query::{AsParams, Query, QuerySimple, RowStream},
     statement::Statement,
-    ToSql,
+    types::ToSql,
 };
 
 pub struct Transaction<'a, C>

--- a/postgres/src/types.rs
+++ b/postgres/src/types.rs
@@ -1,0 +1,6 @@
+//! Types.
+//!
+//! This module is a reexport of the `postgres_types` crate.
+
+#[doc(inline)]
+pub use postgres_types::*;


### PR DESCRIPTION
`BorrowToSql, FromSql, ToSql, Type` have been moved to `types` module