### PR TITLE
fix(client): remove host header on http2 / http3

### DIFF
--- a/client/src/h2/proto/dispatcher.rs
+++ b/client/src/h2/proto/dispatcher.rs
@@ -7,7 +7,7 @@ use xitca_http::{
     http::{
         self,
         const_header_name::PROTOCOL,
-        header::{HeaderValue, CONNECTION, CONTENT_LENGTH, DATE, TRANSFER_ENCODING, UPGRADE},
+        header::{HeaderValue, CONNECTION, CONTENT_LENGTH, DATE, HOST, TRANSFER_ENCODING, UPGRADE},
         method::Method,
     },
 };
@@ -60,6 +60,9 @@ where
     req.headers_mut().remove(CONNECTION);
     req.headers_mut().remove(TRANSFER_ENCODING);
     req.headers_mut().remove(UPGRADE);
+
+    // remove host header if present, some web server may send 400 bad request if host header is present (like nginx)
+    req.headers_mut().remove(HOST);
 
     if !req.headers().contains_key(DATE) {
         let date = date.with_date(HeaderValue::from_bytes).unwrap();

--- a/client/src/h3/proto/dispatcher.rs
+++ b/client/src/h3/proto/dispatcher.rs
@@ -1,19 +1,18 @@
 use core::{future::poll_fn, net::SocketAddr, pin::pin};
 
-use ::h3_quinn::quinn::Endpoint;
-use futures_core::stream::Stream;
-use xitca_http::date::DateTime;
-
 use crate::{
     body::{BodyError, BodySize, ResponseBody},
     bytes::{Buf, Bytes},
     date::DateTimeHandle,
     h3::{Connection, Error},
     http::{
-        header::{HeaderValue, CONTENT_LENGTH, DATE},
+        header::{HeaderValue, CONTENT_LENGTH, DATE, HOST},
         Method, Request, Response,
     },
 };
+use ::h3_quinn::quinn::Endpoint;
+use futures_core::stream::Stream;
+use xitca_http::date::DateTime;
 
 pub(crate) async fn send<B, E>(
     stream: &mut Connection,
@@ -48,6 +47,9 @@ where
             false
         }
     };
+
+    // remove host header if present, some web server may send 400 bad request if host header is present.
+    req.headers_mut().remove(HOST);
 
     if !req.headers().contains_key(DATE) {
         let date = date.with_date(HeaderValue::from_bytes).unwrap();


### PR DESCRIPTION
Hey,

I was playing a bit with the client, and it seems that it has the same bug as the client from actix-web https://github.com/actix/actix-web/issues/3495 where having an host header on nginx will cause a 400.

This header is not used when on http2/http3 since it use the pseudo authority header, so i removed it in both cases to avoid this problem (don't know if nginx will have the same problem with http3, but at least it prevent it and should be harmless)