### PR TITLE
feat(client): use max http version of client by default instead of http 1.1

### DIFF
--- a/client/src/middleware/redirect.rs
+++ b/client/src/middleware/redirect.rs
@@ -28,12 +28,25 @@ where
     type Error = Error;
 
     async fn call(&self, req: ServiceRequest<'r, 'c>) -> Result<Self::Response, Self::Error> {
-        let ServiceRequest { req, client, timeout } = req;
+        let ServiceRequest {
+            req,
+            client,
+            timeout,
+            version,
+        } = req;
         let mut headers = req.headers().clone();
         let mut method = req.method().clone();
         let mut uri = req.uri().clone();
         loop {
-            let mut res = self.service.call(ServiceRequest { req, client, timeout }).await?;
+            let mut res = self
+                .service
+                .call(ServiceRequest {
+                    req,
+                    client,
+                    timeout,
+                    version,
+                })
+                .await?;
             match res.status() {
                 StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND | StatusCode::SEE_OTHER => {
                     if method != Method::HEAD {

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -66,6 +66,7 @@ where
 /// [RequestBuilder]: crate::request::RequestBuilder
 pub struct ServiceRequest<'r, 'c> {
     pub req: &'r mut Request<BoxBody>,
+    pub version: Option<Version>,
     pub client: &'c Client,
     pub timeout: Duration,
 }
@@ -85,14 +86,19 @@ pub(crate) fn base_service() -> HttpService {
             #[cfg(any(feature = "http1", feature = "http2", feature = "http3"))]
             use crate::{error::TimeoutError, timeout::Timeout};
 
-            let ServiceRequest { req, client, timeout } = req;
+            let ServiceRequest {
+                req,
+                version,
+                client,
+                timeout,
+            } = req;
 
             let uri = Uri::try_parse(req.uri())?;
 
             // temporary version to record possible version downgrade/upgrade happens when making connections.
             // alpn protocol and alt-svc header are possible source of version change.
             #[allow(unused_mut)]
-            let mut version = req.version();
+            let mut version = version.unwrap_or(client.max_http_version);
 
             let mut connect = Connect::new(uri);
 


### PR DESCRIPTION
Currently, when creating a request, it's default to HTTP1.1 (which is the default value for this field), end user have to explicitly set the version to HTTP2 / HTTP3.

Which makes the following comment `By default request's HTTP version depends on network stream` wrong since it will always use HTTP1.1 by default

New behavior will use the max http version of the client by default and downgrade to one that it supported (was already the case, but changed the comment to point it out).

Downside of this, is when HTTP3 is enabled and in max version it may timeout.

I'm also wondering if this should be renamed to `max_http_version` for the request method it may reflect better the intention behind that.