### PR TITLE
feat(client): allow to specify a specific remote adress on client request

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -288,11 +288,13 @@ impl Client {
         connect: &mut Connect<'_>,
         timer: &mut Pin<Box<Sleep>>,
     ) -> Result<ConnectionExclusive, Error> {
-        self.resolver
-            .call(connect)
-            .timeout(timer.as_mut())
-            .await
-            .map_err(|_| TimeoutError::Resolve)??;
+        if !connect.is_resolved() {
+            self.resolver
+                .call(connect)
+                .timeout(timer.as_mut())
+                .await
+                .map_err(|_| TimeoutError::Resolve)??;
+        }
 
         timer
             .as_mut()

--- a/client/src/connect.rs
+++ b/client/src/connect.rs
@@ -84,13 +84,16 @@ pub struct Connect<'a> {
 
 impl<'a> Connect<'a> {
     /// Create `Connect` instance by splitting the string by ':' and convert the second part to u16
-    pub fn new(uri: Uri<'a>) -> Self {
+    pub fn new(uri: Uri<'a>, address: Option<SocketAddr>) -> Self {
         let (_, port) = parse_host(uri.hostname());
 
         Self {
             uri,
             port: port.unwrap_or(0),
-            addr: Addrs::None,
+            addr: match address {
+                Some(address) => Addrs::One(address),
+                None => Addrs::None,
+            },
         }
     }
 
@@ -123,6 +126,15 @@ impl<'a> Connect<'a> {
             Addrs::None => AddrsIter::None,
             Addrs::One(addr) => AddrsIter::One(addr),
             Addrs::Multi(ref addrs) => AddrsIter::Multi(addrs.iter()),
+        }
+    }
+
+    /// Check if address is resolved.
+    pub fn is_resolved(&self) -> bool {
+        match self.addr {
+            Addrs::None => false,
+            Addrs::One(_) => true,
+            Addrs::Multi(ref addrs) => !addrs.is_empty(),
         }
     }
 }

--- a/client/src/middleware/redirect.rs
+++ b/client/src/middleware/redirect.rs
@@ -28,12 +28,25 @@ where
     type Error = Error;
 
     async fn call(&self, req: ServiceRequest<'r, 'c>) -> Result<Self::Response, Self::Error> {
-        let ServiceRequest { req, client, timeout } = req;
+        let ServiceRequest {
+            req,
+            address,
+            client,
+            timeout,
+        } = req;
         let mut headers = req.headers().clone();
         let mut method = req.method().clone();
         let mut uri = req.uri().clone();
         loop {
-            let mut res = self.service.call(ServiceRequest { req, client, timeout }).await?;
+            let mut res = self
+                .service
+                .call(ServiceRequest {
+                    req,
+                    address,
+                    client,
+                    timeout,
+                })
+                .await?;
             match res.status() {
                 StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND | StatusCode::SEE_OTHER => {
                     if method != Method::HEAD {

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -1,4 +1,4 @@
-use core::{marker::PhantomData, time::Duration};
+use core::{marker::PhantomData, net::SocketAddr, time::Duration};
 
 use futures_core::Stream;
 
@@ -21,6 +21,7 @@ pub struct RequestBuilder<'a, M = marker::Http> {
     pub(crate) req: http::Request<BoxBody>,
     err: Vec<Error>,
     client: &'a Client,
+    address: Option<SocketAddr>,
     timeout: Duration,
     _marker: PhantomData<M>,
 }
@@ -35,6 +36,13 @@ impl RequestBuilder<'_, marker::Http> {
     #[inline]
     pub fn method(mut self, method: Method) -> Self {
         *self.req.method_mut() = method;
+        self
+    }
+
+    /// Set specific address for this request.
+    #[inline]
+    pub fn address(mut self, addr: SocketAddr) -> Self {
+        self.address = Some(addr);
         self
     }
 
@@ -102,6 +110,7 @@ impl<'a, M> RequestBuilder<'a, M> {
         Self {
             req: req.map(BoxBody::new),
             err: Vec::new(),
+            address: None,
             client,
             timeout: client.timeout_config.request_timeout,
             _marker: PhantomData,
@@ -112,6 +121,7 @@ impl<'a, M> RequestBuilder<'a, M> {
         RequestBuilder {
             req: self.req,
             err: self.err,
+            address: self.address,
             client: self.client,
             timeout: self.timeout,
             _marker: PhantomData,
@@ -123,6 +133,7 @@ impl<'a, M> RequestBuilder<'a, M> {
         let Self {
             mut req,
             err,
+            address,
             client,
             timeout,
             ..
@@ -136,6 +147,7 @@ impl<'a, M> RequestBuilder<'a, M> {
             .service
             .call(ServiceRequest {
                 req: &mut req,
+                address,
                 client,
                 timeout,
             })

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -1,4 +1,4 @@
-use core::{future::Future, pin::Pin, time::Duration};
+use core::{future::Future, net::SocketAddr, pin::Pin, time::Duration};
 
 use crate::{
     body::BoxBody,
@@ -66,6 +66,7 @@ where
 /// [RequestBuilder]: crate::request::RequestBuilder
 pub struct ServiceRequest<'r, 'c> {
     pub req: &'r mut Request<BoxBody>,
+    pub address: Option<SocketAddr>,
     pub client: &'c Client,
     pub timeout: Duration,
 }
@@ -85,7 +86,12 @@ pub(crate) fn base_service() -> HttpService {
             #[cfg(any(feature = "http1", feature = "http2", feature = "http3"))]
             use crate::{error::TimeoutError, timeout::Timeout};
 
-            let ServiceRequest { req, client, timeout } = req;
+            let ServiceRequest {
+                req,
+                address,
+                client,
+                timeout,
+            } = req;
 
             let uri = Uri::try_parse(req.uri())?;
 
@@ -94,7 +100,7 @@ pub(crate) fn base_service() -> HttpService {
             #[allow(unused_mut)]
             let mut version = req.version();
 
-            let mut connect = Connect::new(uri);
+            let mut connect = Connect::new(uri, address);
 
             let _date = client.date_service.handle();
 


### PR DESCRIPTION
This add the possibility to set a specific socket address for a request which can be useful during testing or when you already know the target server ip address / port

