### PR TITLE
feat(client): allow to set response timeout per request

### DIFF
--- a/client/src/middleware/redirect.rs
+++ b/client/src/middleware/redirect.rs
@@ -49,7 +49,12 @@ where
     type Error = Error;
 
     async fn call(&self, req: ServiceRequest<'r, 'c>) -> Result<Self::Response, Self::Error> {
-        let ServiceRequest { req, client, timeout } = req;
+        let ServiceRequest {
+            req,
+            client,
+            request_timeout,
+            response_timeout,
+        } = req;
         let mut headers = req.headers().clone();
         let mut method = req.method().clone();
         let mut uri = req.uri().clone();
@@ -57,7 +62,15 @@ where
         let mut count = 0;
 
         loop {
-            let mut res = self.service.call(ServiceRequest { req, client, timeout }).await?;
+            let mut res = self
+                .service
+                .call(ServiceRequest {
+                    req,
+                    client,
+                    request_timeout,
+                    response_timeout,
+                })
+                .await?;
 
             if count == MAX {
                 return Ok(res);

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -20,7 +20,8 @@ pub struct RequestBuilder<'a, M = marker::Http> {
     pub(crate) req: http::Request<BoxBody>,
     pub(crate) err: Vec<Error>,
     client: &'a Client,
-    timeout: Duration,
+    request_timeout: Duration,
+    response_timeout: Duration,
     _marker: PhantomData<M>,
 }
 
@@ -102,7 +103,8 @@ impl<'a, M> RequestBuilder<'a, M> {
             req: req.map(BoxBody::new),
             err: Vec::new(),
             client,
-            timeout: client.timeout_config.request_timeout,
+            request_timeout: client.timeout_config.request_timeout,
+            response_timeout: client.timeout_config.response_timeout,
             _marker: PhantomData,
         }
     }
@@ -112,7 +114,8 @@ impl<'a, M> RequestBuilder<'a, M> {
             req: self.req,
             err: self.err,
             client: self.client,
-            timeout: self.timeout,
+            request_timeout: self.request_timeout,
+            response_timeout: self.response_timeout,
             _marker: PhantomData,
         }
     }
@@ -123,7 +126,8 @@ impl<'a, M> RequestBuilder<'a, M> {
             mut req,
             err,
             client,
-            timeout,
+            request_timeout,
+            response_timeout,
             ..
         } = self;
 
@@ -136,7 +140,8 @@ impl<'a, M> RequestBuilder<'a, M> {
             .call(ServiceRequest {
                 req: &mut req,
                 client,
-                timeout,
+                request_timeout,
+                response_timeout,
             })
             .await
     }
@@ -198,14 +203,19 @@ impl<'a, M> RequestBuilder<'a, M> {
         self
     }
 
-    /// Set timeout of this request.
+    /// Set timeout for request.
     ///
-    /// The value passed would override global [ClientBuilder::set_request_timeout].
+    /// Default to client's [TimeoutConfig::request_timeout].
+    pub fn set_request_timeout(mut self, dur: Duration) -> Self {
+        self.request_timeout = dur;
+        self
+    }
+
+    /// Set timeout for collecting response body.
     ///
-    /// [ClientBuilder::set_request_timeout]: crate::builder::ClientBuilder::set_request_timeout
-    #[inline]
-    pub fn timeout(mut self, dur: Duration) -> Self {
-        self.timeout = dur;
+    /// Default to client's [TimeoutConfig::response_timeout].
+    pub fn set_response_timeout(mut self, dur: Duration) -> Self {
+        self.response_timeout = dur;
         self
     }
 

--- a/client/src/service/mod.rs
+++ b/client/src/service/mod.rs
@@ -68,7 +68,8 @@ where
 pub struct ServiceRequest<'r, 'c> {
     pub req: &'r mut Request<BoxBody>,
     pub client: &'c Client,
-    pub timeout: Duration,
+    pub request_timeout: Duration,
+    pub response_timeout: Duration,
 }
 
 #[cfg(test)]
@@ -114,7 +115,8 @@ mod test {
             ServiceRequest {
                 req,
                 client: &self.0,
-                timeout: self.0.timeout_config.request_timeout,
+                request_timeout: self.0.timeout_config.request_timeout,
+                response_timeout: self.0.timeout_config.response_timeout,
             }
         }
     }
@@ -125,7 +127,9 @@ mod test {
 
         async fn call(
             &self,
-            ServiceRequest { req, timeout, .. }: ServiceRequest<'r, 'c>,
+            ServiceRequest {
+                req, response_timeout, ..
+            }: ServiceRequest<'r, 'c>,
         ) -> Result<Self::Response, Self::Error> {
             let handler = req.extensions().get::<HandlerFn>().unwrap().clone();
 
@@ -134,7 +138,7 @@ mod test {
             Ok(Response::new(
                 res,
                 Box::pin(tokio::time::sleep(Duration::from_secs(0))),
-                timeout,
+                response_timeout,
             ))
         }
     }


### PR DESCRIPTION
This allow configuring all timeout options per request instead of having only the request timeout set (obviously connect / tls timeout may not be used each time will depend on the pool)

EDIT : PR changed to only specifying request / response timeout instead of all possible one