### PR TITLE
feat(client): allow to set a specific sni hostname per request

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -269,7 +269,7 @@ impl Client {
 
                 let (conn, version) = self
                     .connector
-                    .call((connect.hostname(), conn))
+                    .call((connect.sni_hostname(), conn))
                     .timeout(timer.as_mut())
                     .await
                     .map_err(|_| TimeoutError::TlsHandshake)??;

--- a/client/src/connect.rs
+++ b/client/src/connect.rs
@@ -80,17 +80,19 @@ pub struct Connect<'a> {
     pub(crate) uri: Uri<'a>,
     pub(crate) port: u16,
     pub(crate) addr: Addrs,
+    pub(crate) sni_hostname: Option<&'a str>,
 }
 
 impl<'a> Connect<'a> {
     /// Create `Connect` instance by splitting the string by ':' and convert the second part to u16
-    pub fn new(uri: Uri<'a>) -> Self {
+    pub fn new(uri: Uri<'a>, sni_hostname: Option<&'a str>) -> Self {
         let (_, port) = parse_host(uri.hostname());
 
         Self {
             uri,
             port: port.unwrap_or(0),
             addr: Addrs::None,
+            sni_hostname,
         }
     }
 
@@ -110,6 +112,11 @@ impl<'a> Connect<'a> {
     /// Get hostname.
     pub fn hostname(&self) -> &str {
         self.uri.hostname()
+    }
+
+    /// Get sni hostname.
+    pub fn sni_hostname(&self) -> &str {
+        self.sni_hostname.unwrap_or_else(|| self.hostname())
     }
 
     /// Get request port.

--- a/client/src/middleware/redirect.rs
+++ b/client/src/middleware/redirect.rs
@@ -28,12 +28,25 @@ where
     type Error = Error;
 
     async fn call(&self, req: ServiceRequest<'r, 'c>) -> Result<Self::Response, Self::Error> {
-        let ServiceRequest { req, client, timeout } = req;
+        let ServiceRequest {
+            req,
+            client,
+            timeout,
+            sni_hostname,
+        } = req;
         let mut headers = req.headers().clone();
         let mut method = req.method().clone();
         let mut uri = req.uri().clone();
         loop {
-            let mut res = self.service.call(ServiceRequest { req, client, timeout }).await?;
+            let mut res = self
+                .service
+                .call(ServiceRequest {
+                    req,
+                    client,
+                    timeout,
+                    sni_hostname,
+                })
+                .await?;
             match res.status() {
                 StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND | StatusCode::SEE_OTHER => {
                     if method != Method::HEAD {

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -22,6 +22,7 @@ pub struct RequestBuilder<'a, M = marker::Http> {
     err: Vec<Error>,
     client: &'a Client,
     timeout: Duration,
+    sni_hostname: Option<String>,
     _marker: PhantomData<M>,
 }
 
@@ -104,6 +105,7 @@ impl<'a, M> RequestBuilder<'a, M> {
             err: Vec::new(),
             client,
             timeout: client.timeout_config.request_timeout,
+            sni_hostname: None,
             _marker: PhantomData,
         }
     }
@@ -114,6 +116,7 @@ impl<'a, M> RequestBuilder<'a, M> {
             err: self.err,
             client: self.client,
             timeout: self.timeout,
+            sni_hostname: self.sni_hostname,
             _marker: PhantomData,
         }
     }
@@ -138,6 +141,7 @@ impl<'a, M> RequestBuilder<'a, M> {
                 req: &mut req,
                 client,
                 timeout,
+                sni_hostname: self.sni_hostname.as_deref(),
             })
             .await
     }
@@ -207,6 +211,13 @@ impl<'a, M> RequestBuilder<'a, M> {
     #[inline]
     pub fn timeout(mut self, dur: Duration) -> Self {
         self.timeout = dur;
+        self
+    }
+
+    /// Set SNI hostname of this request.
+    #[inline]
+    pub fn sni_hostname(mut self, sni_hostname: String) -> Self {
+        self.sni_hostname = Some(sni_hostname);
         self
     }
 

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -68,6 +68,7 @@ pub struct ServiceRequest<'r, 'c> {
     pub req: &'r mut Request<BoxBody>,
     pub client: &'c Client,
     pub timeout: Duration,
+    pub sni_hostname: Option<&'r str>,
 }
 
 /// type alias for object safe wrapper of type implement [Service] trait.
@@ -85,7 +86,12 @@ pub(crate) fn base_service() -> HttpService {
             #[cfg(any(feature = "http1", feature = "http2", feature = "http3"))]
             use crate::{error::TimeoutError, timeout::Timeout};
 
-            let ServiceRequest { req, client, timeout } = req;
+            let ServiceRequest {
+                req,
+                client,
+                timeout,
+                sni_hostname,
+            } = req;
 
             let uri = Uri::try_parse(req.uri())?;
 
@@ -94,7 +100,7 @@ pub(crate) fn base_service() -> HttpService {
             #[allow(unused_mut)]
             let mut version = req.version();
 
-            let mut connect = Connect::new(uri);
+            let mut connect = Connect::new(uri, sni_hostname);
 
             let _date = client.date_service.handle();
 
@@ -155,7 +161,7 @@ pub(crate) fn base_service() -> HttpService {
                                     if let Ok(Ok(conn)) = crate::h3::proto::connect(
                                         &client.h3_client,
                                         connect.addrs(),
-                                        connect.hostname(),
+                                        connect.sni_hostname(),
                                     )
                                     .timeout(timer.as_mut())
                                     .await


### PR DESCRIPTION
This allow to set a specific hostname for sni, use the request hostname like before by default, but allow to change it if needed.

Still in draft, i think the pool connection key need to be aware of this field, so we don't reuse the same connection if we want a different sni but we are requesting the same host.