### PR TITLE
feat(client): add support for upgrade request

### DIFF
--- a/client/src/http_tunnel.rs
+++ b/client/src/http_tunnel.rs
@@ -51,13 +51,13 @@ impl HttpTunnelRequest<'_> {
 }
 
 pub struct HttpTunnel {
-    body: ResponseBody,
-    io: TunnelIo,
+    pub(crate) body: ResponseBody,
+    pub(crate) io: TunnelIo,
 }
 
 // io type to bridge AsyncIo trait and h2 body's poll based read/write apis.
 #[derive(Default)]
-struct TunnelIo {
+pub(crate) struct TunnelIo {
     write_buf: BytesMut,
     #[cfg(feature = "http2")]
     adaptor: TunnelIoAdaptor,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -43,6 +43,7 @@ mod service;
 mod timeout;
 mod tls;
 mod tunnel;
+mod upgrade;
 mod uri;
 
 #[cfg(feature = "http1")]

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -19,7 +19,7 @@ use crate::{
 /// builder type for [http::Request] with extended functionalities.
 pub struct RequestBuilder<'a, M = marker::Http> {
     pub(crate) req: http::Request<BoxBody>,
-    err: Vec<Error>,
+    pub(crate) err: Vec<Error>,
     client: &'a Client,
     timeout: Duration,
     _marker: PhantomData<M>,

--- a/client/src/upgrade.rs
+++ b/client/src/upgrade.rs
@@ -1,0 +1,102 @@
+//! http upgrade handling.
+
+use super::{
+    error::{Error, ErrorResponse},
+    http::{
+        header::{self, HeaderValue},
+        response::Parts,
+        StatusCode,
+    },
+    http_tunnel::HttpTunnel,
+    request::RequestBuilder,
+    tunnel::Tunnel,
+};
+use std::ops::{Deref, DerefMut};
+
+pub type UpgradeRequest<'a> = RequestBuilder<'a, marker::Upgrade>;
+pub type UpgradeRequestWithProtocol<'a> = RequestBuilder<'a, marker::UpgradeWithProtocol>;
+
+mod marker {
+    pub struct Upgrade;
+    pub struct UpgradeWithProtocol;
+}
+
+pub struct UpgradeResponse {
+    pub parts: Parts,
+    pub tunnel: Tunnel<HttpTunnel>,
+}
+
+impl<'a> UpgradeRequest<'a> {
+    pub fn protocol<V>(mut self, proto: V) -> UpgradeRequestWithProtocol<'a>
+    where
+        V: TryInto<HeaderValue>,
+        V::Error: std::error::Error + Send + Sync + 'static,
+    {
+        match proto.try_into() {
+            Ok(v) => {
+                self.req.headers_mut().insert(header::UPGRADE, v);
+            }
+            Err(e) => {
+                self.push_error(Error::Std(Box::new(e)));
+            }
+        };
+
+        self.mutate_marker()
+    }
+}
+
+impl UpgradeRequestWithProtocol<'_> {
+    /// Send the request and wait for response asynchronously.
+    pub async fn send(mut self) -> Result<UpgradeResponse, Error> {
+        self.headers_mut()
+            .insert(header::CONNECTION, HeaderValue::from_static("upgrade"));
+
+        let res = self._send().await?;
+
+        let status = res.status();
+        let expect_status = StatusCode::SWITCHING_PROTOCOLS;
+        if status != expect_status {
+            return Err(Error::from(ErrorResponse {
+                expect_status,
+                status,
+                description: "upgrade tunnel can't be established",
+            }));
+        }
+
+        let (parts, body) = res.into_inner().into_parts();
+
+        Ok(UpgradeResponse {
+            parts,
+            tunnel: Tunnel::new(HttpTunnel {
+                body,
+                io: Default::default(),
+            }),
+        })
+    }
+}
+
+impl UpgradeResponse {
+    #[inline]
+    pub fn into_parts(self) -> (Parts, Tunnel<HttpTunnel>) {
+        (self.parts, self.tunnel)
+    }
+
+    #[inline]
+    pub fn tunnel(&mut self) -> &mut Tunnel<HttpTunnel> {
+        &mut self.tunnel
+    }
+}
+
+impl Deref for UpgradeResponse {
+    type Target = Parts;
+
+    fn deref(&self) -> &Self::Target {
+        &self.parts
+    }
+}
+
+impl DerefMut for UpgradeResponse {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.parts
+    }
+}


### PR DESCRIPTION
This PR allow a user to upgrade an HTTP request (only on http1 feature since it's not allowed on other protocol)

It's very similar to the connect api, it just have different check (add a special header for connection and check the switching protocl status code), i also added the headers to the response (since it can be needed to know on which protocol you have to upgrade).