### PR TITLE
feat(web): allow to bind h3 on web app

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -18,7 +18,7 @@ default = ["http1"]
 # extended http versions
 http1 = ["__server", "xitca-http/http1"]
 http2 = ["__server", "xitca-http/http2"]
-http3 = ["__server", "xitca-http/http3"]
+http3 = ["__server", "xitca-http/http3", "xitca-server/quic", "xitca-io/quic"]
 
 # linux io-uring async file io
 io-uring = ["__server", "xitca-server/io-uring"]
@@ -135,6 +135,9 @@ xitca-codegen = { version = "0.4.0", optional = true }
 tower-service = { version = "0.3", optional = true }
 tower-layer = { version = "0.3", optional = true }
 http-body = { version = "1", optional = true }
+
+# http3
+xitca-io = { version = "0.4.1", optional = true }
 
 [dev-dependencies]
 xitca-codegen = { version = "0.4" }


### PR DESCRIPTION
Maybe i miss something but actually binding web to h3 require a lot of boilerplate, this pr allow simplify this by adding a bind_h3 method to the app.

Since it need a QuicConfig i'm wondering if we should add a reexport for the QuicConfig (but can be done later)