### PR TITLE
feat(http): add information on request to know it it's from tls or not

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -263,6 +263,10 @@ impl Client {
                     return Ok((conn, expected_version));
                 }
 
+                if !connect.tls {
+                    return Ok((conn, expected_version));
+                }
+
                 timer
                     .as_mut()
                     .reset(Instant::now() + self.timeout_config.tls_connect_timeout);

--- a/client/src/connect.rs
+++ b/client/src/connect.rs
@@ -80,17 +80,19 @@ pub struct Connect<'a> {
     pub(crate) uri: Uri<'a>,
     pub(crate) port: u16,
     pub(crate) addr: Addrs,
+    pub(crate) tls: bool,
 }
 
 impl<'a> Connect<'a> {
     /// Create `Connect` instance by splitting the string by ':' and convert the second part to u16
-    pub fn new(uri: Uri<'a>) -> Self {
+    pub fn new(uri: Uri<'a>, tls: Option<bool>) -> Self {
         let (_, port) = parse_host(uri.hostname());
 
         Self {
             uri,
             port: port.unwrap_or(0),
             addr: Addrs::None,
+            tls: tls.unwrap_or(port != Some(80)),
         }
     }
 

--- a/client/src/h1/proto/context.rs
+++ b/client/src/h1/proto/context.rs
@@ -29,7 +29,7 @@ impl<const HEADER_LIMIT: usize> DerefMut for Context<'_, '_, HEADER_LIMIT> {
 }
 
 impl<'c, 'd, const HEADER_LIMIT: usize> Context<'c, 'd, HEADER_LIMIT> {
-    pub(crate) fn new(date: &'c DateTimeHandle<'d>) -> Self {
-        Self(context::Context::new(date))
+    pub(crate) fn new(date: &'c DateTimeHandle<'d>, is_tls: bool) -> Self {
+        Self(context::Context::new(date, is_tls))
     }
 }

--- a/client/src/h1/proto/dispatcher.rs
+++ b/client/src/h1/proto/dispatcher.rs
@@ -23,6 +23,7 @@ pub(crate) async fn send<S, B, E>(
     stream: &mut S,
     date: DateTimeHandle<'_>,
     req: &mut Request<B>,
+    is_tls: bool,
 ) -> Result<(Response<()>, BytesMut, TransferCoding, bool), Error>
 where
     S: AsyncIo + Unpin,
@@ -69,7 +70,7 @@ where
     }
 
     // TODO: make const generic params configurable.
-    let mut ctx = Context::<128>::new(&date);
+    let mut ctx = Context::<128>::new(&date, is_tls);
 
     // encode request head and return transfer encoding for request body
     let encoder = ctx.encode_head(&mut buf, req)?;

--- a/client/src/middleware/redirect.rs
+++ b/client/src/middleware/redirect.rs
@@ -28,12 +28,25 @@ where
     type Error = Error;
 
     async fn call(&self, req: ServiceRequest<'r, 'c>) -> Result<Self::Response, Self::Error> {
-        let ServiceRequest { req, client, timeout } = req;
+        let ServiceRequest {
+            req,
+            client,
+            timeout,
+            tls,
+        } = req;
         let mut headers = req.headers().clone();
         let mut method = req.method().clone();
         let mut uri = req.uri().clone();
         loop {
-            let mut res = self.service.call(ServiceRequest { req, client, timeout }).await?;
+            let mut res = self
+                .service
+                .call(ServiceRequest {
+                    req,
+                    client,
+                    timeout,
+                    tls,
+                })
+                .await?;
             match res.status() {
                 StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND | StatusCode::SEE_OTHER => {
                     if method != Method::HEAD {

--- a/client/src/request.rs
+++ b/client/src/request.rs
@@ -22,6 +22,7 @@ pub struct RequestBuilder<'a, M = marker::Http> {
     err: Vec<Error>,
     client: &'a Client,
     timeout: Duration,
+    tls: Option<bool>,
     _marker: PhantomData<M>,
 }
 
@@ -104,6 +105,7 @@ impl<'a, M> RequestBuilder<'a, M> {
             err: Vec::new(),
             client,
             timeout: client.timeout_config.request_timeout,
+            tls: None,
             _marker: PhantomData,
         }
     }
@@ -114,6 +116,7 @@ impl<'a, M> RequestBuilder<'a, M> {
             err: self.err,
             client: self.client,
             timeout: self.timeout,
+            tls: self.tls,
             _marker: PhantomData,
         }
     }
@@ -125,6 +128,7 @@ impl<'a, M> RequestBuilder<'a, M> {
             err,
             client,
             timeout,
+            tls,
             ..
         } = self;
 
@@ -138,6 +142,7 @@ impl<'a, M> RequestBuilder<'a, M> {
                 req: &mut req,
                 client,
                 timeout,
+                tls,
             })
             .await
     }
@@ -207,6 +212,13 @@ impl<'a, M> RequestBuilder<'a, M> {
     #[inline]
     pub fn timeout(mut self, dur: Duration) -> Self {
         self.timeout = dur;
+        self
+    }
+
+    /// Set TLS state of this request.
+    #[inline]
+    pub fn tls(mut self, tls: bool) -> Self {
+        self.tls = Some(tls);
         self
     }
 

--- a/http/src/h1/dispatcher_uring.rs
+++ b/http/src/h1/dispatcher_uring.rs
@@ -118,11 +118,12 @@ where
         config: HttpServiceConfig<H_LIMIT, R_LIMIT, W_LIMIT>,
         service: &'a S,
         date: &'a D,
+        is_tls: bool,
     ) -> Self {
         Self {
             io: Rc::new(io),
             timer: Timer::new(timer, config.keep_alive_timeout, config.request_head_timeout),
-            ctx: Context::<_, H_LIMIT>::with_addr(addr, date),
+            ctx: Context::<_, H_LIMIT>::with_addr(addr, date, is_tls),
             service,
             read_buf: BufOwned::new(),
             write_buf: BufOwned::new(),

--- a/http/src/h1/proto/context.rs
+++ b/http/src/h1/proto/context.rs
@@ -11,6 +11,7 @@ pub struct Context<'a, D, const HEADER_LIMIT: usize> {
     // http extensions reused by next request.
     exts: Extensions,
     date: &'a D,
+    is_tls: bool,
 }
 
 // A set of state for current request that are used after request's ownership is passed
@@ -49,21 +50,22 @@ impl<'a, D, const HEADER_LIMIT: usize> Context<'a, D, HEADER_LIMIT> {
     ///
     /// [DateTime]: crate::date::DateTime
     #[inline]
-    pub fn new(date: &'a D) -> Self {
-        Self::with_addr(crate::unspecified_socket_addr(), date)
+    pub fn new(date: &'a D, is_tls: bool) -> Self {
+        Self::with_addr(crate::unspecified_socket_addr(), date, is_tls)
     }
 
     /// Context is constructed with [SocketAddr] and reference of certain type that impl [DateTime] trait.
     ///
     /// [DateTime]: crate::date::DateTime
     #[inline]
-    pub fn with_addr(addr: SocketAddr, date: &'a D) -> Self {
+    pub fn with_addr(addr: SocketAddr, date: &'a D, is_tls: bool) -> Self {
         Self {
             addr,
             state: ContextState::new(),
             header: None,
             exts: Extensions::new(),
             date,
+            is_tls,
         }
     }
 
@@ -71,6 +73,12 @@ impl<'a, D, const HEADER_LIMIT: usize> Context<'a, D, HEADER_LIMIT> {
     #[inline]
     pub fn date(&self) -> &D {
         self.date
+    }
+
+    /// Check if current connection is secure.
+    #[inline]
+    pub fn is_tls(&self) -> bool {
+        self.is_tls
     }
 
     /// Take ownership of HeaderMap stored in Context.

--- a/http/src/h1/proto/decode.rs
+++ b/http/src/h1/proto/decode.rs
@@ -82,7 +82,7 @@ impl<D, const MAX_HEADERS: usize> Context<'_, D, MAX_HEADERS> {
                     self.try_write_header(&mut headers, &mut decoder, idx, &slice, version)?;
                 }
 
-                let ext = Extension::new(*self.socket_addr());
+                let ext = Extension::new(*self.socket_addr(), self.is_tls());
                 let mut req = Request::new(RequestExt::from_parts((), ext));
 
                 let extensions = self.take_extensions();
@@ -173,7 +173,7 @@ mod test {
 
     #[test]
     fn connection_multiple_value() {
-        let mut ctx = Context::<_, 4>::new(&());
+        let mut ctx = Context::<_, 4>::new(&(), false);
 
         let head = b"\
                 GET / HTTP/1.1\r\n\
@@ -211,7 +211,7 @@ mod test {
 
     #[test]
     fn transfer_encoding() {
-        let mut ctx = Context::<_, 4>::new(&());
+        let mut ctx = Context::<_, 4>::new(&(), false);
 
         let head = b"\
                 GET / HTTP/1.1\r\n\

--- a/http/src/h1/proto/encode.rs
+++ b/http/src/h1/proto/encode.rs
@@ -257,7 +257,7 @@ mod test {
 
     #[test]
     fn append_header() {
-        let mut ctx = Context::<_, 64>::new(&SystemTimeDateTimeHandler);
+        let mut ctx = Context::<_, 64>::new(&SystemTimeDateTimeHandler, false);
 
         let mut res = Response::new(BoxBody::new(Once::new(Bytes::new())));
 
@@ -287,7 +287,7 @@ mod test {
 
     #[test]
     fn multi_set_cookie() {
-        let mut ctx = Context::<_, 64>::new(&SystemTimeDateTimeHandler);
+        let mut ctx = Context::<_, 64>::new(&SystemTimeDateTimeHandler, false);
 
         let mut res = Response::new(BoxBody::new(Once::new(Bytes::new())));
 

--- a/http/src/h1/service.rs
+++ b/http/src/h1/service.rs
@@ -21,7 +21,7 @@ impl<St, S, B, BE, A, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, co
     Service<(St, SocketAddr)> for H1Service<St, S, A, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
 where
     S: Service<Request<RequestExt<RequestBody>>, Response = Response<B>>,
-    A: Service<St>,
+    A: Service<St> + IsTls,
     St: AsyncIo,
     A::Response: AsyncIo,
     B: Stream<Item = Result<Bytes, BE>>,
@@ -41,9 +41,17 @@ where
             .await
             .map_err(|_| HttpServiceError::Timeout(TimeoutError::TlsAccept))??;
 
-        super::dispatcher::run(&mut io, addr, timer, self.config, &self.service, self.date.get())
-            .await
-            .map_err(Into::into)
+        super::dispatcher::run(
+            &mut io,
+            addr,
+            timer,
+            self.config,
+            &self.service,
+            self.date.get(),
+            self.tls_acceptor.is_tls(),
+        )
+        .await
+        .map_err(Into::into)
     }
 }
 
@@ -56,6 +64,7 @@ use {
     xitca_service::ready::ReadyService,
 };
 
+use crate::tls::IsTls;
 #[cfg(feature = "io-uring")]
 use crate::{
     config::HttpServiceConfig,
@@ -94,7 +103,7 @@ impl<S, B, BE, A, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const 
     Service<(TcpStream, SocketAddr)> for H1UringService<S, A, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
 where
     S: Service<Request<RequestExt<RequestBody>>, Response = Response<B>>,
-    A: Service<TcpStream>,
+    A: Service<TcpStream> + IsTls,
     A::Response: AsyncBufRead + AsyncBufWrite + 'static,
     B: Stream<Item = Result<Bytes, BE>>,
     HttpServiceError<S::Error, BE>: From<A::Error>,
@@ -113,10 +122,18 @@ where
             .await
             .map_err(|_| HttpServiceError::Timeout(TimeoutError::TlsAccept))??;
 
-        super::dispatcher_uring::Dispatcher::new(io, addr, timer, self.config, &self.service, self.date.get())
-            .run()
-            .await
-            .map_err(Into::into)
+        super::dispatcher_uring::Dispatcher::new(
+            io,
+            addr,
+            timer,
+            self.config,
+            &self.service,
+            self.date.get(),
+            self.tls_acceptor.is_tls(),
+        )
+        .run()
+        .await
+        .map_err(Into::into)
     }
 }
 

--- a/http/src/h2/proto/dispatcher.rs
+++ b/http/src/h2/proto/dispatcher.rs
@@ -39,6 +39,7 @@ pub(crate) struct Dispatcher<'a, TlsSt, S, ReqB> {
     ka_dur: Duration,
     service: &'a S,
     date: &'a DateTimeHandle,
+    is_tls: bool,
     _req_body: PhantomData<ReqB>,
 }
 
@@ -60,6 +61,7 @@ where
         ka_dur: Duration,
         service: &'a S,
         date: &'a DateTimeHandle,
+        is_tls: bool,
     ) -> Self {
         Self {
             io,
@@ -68,6 +70,7 @@ where
             ka_dur,
             service,
             date,
+            is_tls,
             _req_body: PhantomData,
         }
     }
@@ -80,6 +83,7 @@ where
             ka_dur,
             service,
             date,
+            is_tls,
             ..
         } = self;
 
@@ -107,7 +111,7 @@ where
                     // and reconstruct as HttpRequest.
                     let req = req.map(|body| {
                         let body = ReqB::from(RequestBody::from(body));
-                        RequestExt::from_parts(body, Extension::new(addr))
+                        RequestExt::from_parts(body, Extension::new(addr, is_tls))
                     });
 
                     queue.push(async move {

--- a/http/src/h2/service.rs
+++ b/http/src/h2/service.rs
@@ -32,7 +32,7 @@ where
     S: Service<Request<RequestExt<RequestBody>>, Response = Response<ResB>>,
     S::Error: fmt::Debug,
 
-    A: Service<St, Response = TlsSt>,
+    A: Service<St, Response = TlsSt> + IsTls,
     St: AsyncIo,
     TlsSt: AsyncIo,
 
@@ -73,6 +73,7 @@ where
             self.config.keep_alive_timeout,
             &self.service,
             self.date.get(),
+            self.tls_acceptor.is_tls(),
         );
 
         dispatcher.run().await?;
@@ -81,6 +82,7 @@ where
     }
 }
 
+use crate::tls::IsTls;
 #[cfg(feature = "io-uring")]
 pub(crate) use io_uring::H2UringService;
 

--- a/http/src/h3/proto/dispatcher.rs
+++ b/http/src/h3/proto/dispatcher.rs
@@ -69,7 +69,7 @@ where
                     // Reconstruct Request to attach crate body type.
                     let req = req.map(|_| {
                         let body = ReqB::from(RequestBody(rx));
-                        RequestExt::from_parts(body, Extension::new(self.addr))
+                        RequestExt::from_parts(body, Extension::new(self.addr, true))
                     });
 
                     queue.push(async move {

--- a/http/src/http.rs
+++ b/http/src/http.rs
@@ -146,9 +146,10 @@ where
 pub(crate) struct Extension(Box<_Extension>);
 
 impl Extension {
-    pub(crate) fn new(addr: SocketAddr) -> Self {
+    pub(crate) fn new(addr: SocketAddr, is_tls: bool) -> Self {
         Self(Box::new(_Extension {
             addr,
+            is_tls,
             #[cfg(feature = "router")]
             params: Default::default(),
         }))
@@ -158,6 +159,7 @@ impl Extension {
 #[derive(Clone, Debug)]
 struct _Extension {
     addr: SocketAddr,
+    is_tls: bool,
     #[cfg(feature = "router")]
     params: Params,
 }
@@ -174,6 +176,12 @@ impl<B> RequestExt<B> {
     #[inline]
     pub fn socket_addr(&self) -> &SocketAddr {
         &self.ext.0.addr
+    }
+
+    /// retrieve whether the connection is tls encrypted.
+    #[inline]
+    pub fn is_tls(&self) -> bool {
+        self.ext.0.is_tls
     }
 
     /// exclusive version of [RequestExt::socket_addr]
@@ -209,7 +217,7 @@ where
     B: Default,
 {
     fn default() -> Self {
-        Self::from_parts(B::default(), Extension::new(crate::unspecified_socket_addr()))
+        Self::from_parts(B::default(), Extension::new(crate::unspecified_socket_addr(), false))
     }
 }
 

--- a/http/src/service.rs
+++ b/http/src/service.rs
@@ -14,6 +14,7 @@ use super::{
     date::{DateTime, DateTimeService},
     error::{HttpServiceError, TimeoutError},
     http::{Request, RequestExt, Response},
+    tls::IsTls,
     util::timer::{KeepAlive, Timeout},
     version::AsVersion,
 };
@@ -73,7 +74,7 @@ impl<S, ResB, BE, A, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, con
     for HttpService<ServerStream, S, RequestBody, A, HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT>
 where
     S: Service<Request<RequestExt<RequestBody>>, Response = Response<ResB>>,
-    A: Service<TcpStream>,
+    A: Service<TcpStream> + IsTls,
     A::Response: AsyncIo + AsVersion,
     HttpServiceError<S::Error, BE>: From<A::Error>,
     S::Error: fmt::Debug,
@@ -120,6 +121,7 @@ where
                         self.config,
                         &self.service,
                         self.date.get(),
+                        self.tls_acceptor.is_tls(),
                     )
                     .await
                     .map_err(From::from),
@@ -142,6 +144,7 @@ where
                             self.config.keep_alive_timeout,
                             &self.service,
                             self.date.get(),
+                            self.tls_acceptor.is_tls(),
                         )
                         .run()
                         .await
@@ -168,6 +171,7 @@ where
                         self.config,
                         &self.service,
                         self.date.get(),
+                        false,
                     )
                     .await
                     .map_err(From::from)

--- a/http/src/tls/mod.rs
+++ b/http/src/tls/mod.rs
@@ -34,11 +34,23 @@ impl Service for NoOpTlsAcceptorBuilder {
 
 pub struct NoOpTlsAcceptorService;
 
+pub trait IsTls {
+    fn is_tls(&self) -> bool {
+        true
+    }
+}
+
 impl<St> Service<St> for NoOpTlsAcceptorService {
     type Response = St;
     type Error = TlsError;
 
     async fn call(&self, io: St) -> Result<Self::Response, Self::Error> {
         Ok(io)
+    }
+}
+
+impl IsTls for NoOpTlsAcceptorService {
+    fn is_tls(&self) -> bool {
+        false
     }
 }

--- a/http/src/tls/native_tls.rs
+++ b/http/src/tls/native_tls.rs
@@ -14,9 +14,9 @@ use native_tls::{Error, HandshakeError};
 use xitca_io::io::{AsyncIo, Interest, Ready};
 use xitca_service::Service;
 
-use crate::{http::Version, version::AsVersion};
-
 use super::error::TlsError;
+use crate::tls::IsTls;
+use crate::{http::Version, version::AsVersion};
 
 /// A wrapper type for [TlsStream](native_tls::TlsStream).
 ///
@@ -64,6 +64,8 @@ impl Service for TlsAcceptorBuilder {
 pub struct TlsAcceptorService {
     acceptor: TlsAcceptor,
 }
+
+impl IsTls for TlsAcceptorService {}
 
 impl<St: AsyncIo> Service<St> for TlsAcceptorService {
     type Response = TlsStream<St>;

--- a/http/src/tls/openssl.rs
+++ b/http/src/tls/openssl.rs
@@ -6,9 +6,9 @@ use xitca_io::io::AsyncIo;
 use xitca_service::Service;
 use xitca_tls::openssl::ssl;
 
-use crate::{http::Version, version::AsVersion};
-
 use super::error::TlsError;
+use crate::tls::IsTls;
+use crate::{http::Version, version::AsVersion};
 
 pub type TlsStream<Io> = xitca_tls::openssl::TlsStream<Io>;
 
@@ -51,6 +51,8 @@ impl Service for TlsAcceptorBuilder {
 pub struct TlsAcceptorService {
     acceptor: TlsAcceptor,
 }
+
+impl IsTls for TlsAcceptorService {}
 
 impl TlsAcceptorService {
     #[inline(never)]

--- a/http/src/tls/rustls.rs
+++ b/http/src/tls/rustls.rs
@@ -6,9 +6,9 @@ use xitca_io::io::AsyncIo;
 use xitca_service::Service;
 use xitca_tls::rustls::{Error, ServerConfig, ServerConnection, TlsStream as _TlsStream};
 
-use crate::{http::Version, version::AsVersion};
-
 use super::error::TlsError;
+use crate::tls::IsTls;
+use crate::{http::Version, version::AsVersion};
 
 pub(crate) type RustlsConfig = Arc<ServerConfig>;
 
@@ -54,6 +54,8 @@ impl Service for TlsAcceptorBuilder {
 pub struct TlsAcceptorService {
     acceptor: Arc<ServerConfig>,
 }
+
+impl IsTls for TlsAcceptorService {}
 
 impl<Io: AsyncIo> Service<Io> for TlsAcceptorService {
     type Response = TlsStream<Io>;

--- a/http/src/tls/rustls_uring.rs
+++ b/http/src/tls/rustls_uring.rs
@@ -9,9 +9,9 @@ use xitca_tls::{
     rustls_uring::TlsStream as _TlsStream,
 };
 
-use crate::{http::Version, version::AsVersion};
-
 use super::rustls::RustlsError;
+use crate::tls::IsTls;
+use crate::{http::Version, version::AsVersion};
 
 /// A stream managed by rustls for tls read/write.
 pub struct TlsStream<Io> {
@@ -51,6 +51,8 @@ impl Service for TlsAcceptorBuilder {
 pub struct TlsAcceptorService {
     acceptor: Arc<ServerConfig>,
 }
+
+impl IsTls for TlsAcceptorService {}
 
 impl<Io> Service<Io> for TlsAcceptorService
 where


### PR DESCRIPTION
This PR aims to be able for an user to know if a request comes from a secure context or not.

There is no way to know actually when listening on both secure and not secure context if a incoming request is using tls or not. I added this information to the `Extensions` part of the request, so now an user can, per exemple, automatically redirect an user to https if coming from http.

EDIT : I also updated the client to be able to force using a secure context or not and avoid calling acceptor if not in a secure context