### PR TITLE
fix(client): retry http1 connection if closed by server

### DIFF
--- a/client/src/body.rs
+++ b/client/src/body.rs
@@ -52,10 +52,10 @@ impl ResponseBody {
         }
     }
 
-    pub(crate) fn can_destroy_on_drop(&mut self) -> bool {
+    pub(crate) fn can_destroy_on_drop(&self) -> bool {
         #[cfg(feature = "http1")]
-        if let Self::H1(ref mut body) = *self {
-            return body.conn_mut().is_destroy_on_drop();
+        if let Self::H1(ref body) = *self {
+            return body.conn().is_destroy_on_drop();
         }
 
         false

--- a/client/src/middleware/mod.rs
+++ b/client/src/middleware/mod.rs
@@ -1,6 +1,7 @@
 //! middleware offer extended functionality to http client.
 
 mod redirect;
+mod retry_closed_connection;
 
 #[cfg(feature = "compress")]
 mod decompress;
@@ -9,3 +10,4 @@ mod decompress;
 pub use decompress::Decompress;
 
 pub use redirect::FollowRedirect;
+pub use retry_closed_connection::RetryClosedConnection;

--- a/client/src/middleware/retry_closed_connection.rs
+++ b/client/src/middleware/retry_closed_connection.rs
@@ -1,0 +1,80 @@
+use std::io;
+
+use crate::{
+    error::Error,
+    response::Response,
+    service::{Service, ServiceRequest},
+};
+
+/// middleware for retrying closed connection
+pub struct RetryClosedConnection<S> {
+    service: S,
+}
+
+impl<S> RetryClosedConnection<S> {
+    pub fn new(service: S) -> Self {
+        Self { service }
+    }
+}
+
+impl<'r, 'c, S> Service<ServiceRequest<'r, 'c>> for RetryClosedConnection<S>
+where
+    S: for<'r2, 'c2> Service<ServiceRequest<'r2, 'c2>, Response = Response, Error = Error> + Send + Sync,
+{
+    type Response = Response;
+    type Error = Error;
+
+    async fn call(&self, req: ServiceRequest<'r, 'c>) -> Result<Self::Response, Self::Error> {
+        let ServiceRequest { req, client, timeout } = req;
+        let headers = req.headers().clone();
+        let method = req.method().clone();
+        let uri = req.uri().clone();
+
+        loop {
+            let res = self.service.call(ServiceRequest { req, client, timeout }).await;
+
+            match res {
+                Err(Error::Io(err)) => {
+                    if err.kind() != io::ErrorKind::UnexpectedEof {
+                        return Err(Error::Io(err));
+                    }
+                }
+                #[cfg(feature = "http1")]
+                Err(Error::H1(crate::h1::Error::Io(err))) => {
+                    if err.kind() != io::ErrorKind::UnexpectedEof {
+                        return Err(Error::H1(crate::h1::Error::Io(err)));
+                    }
+                }
+                #[cfg(feature = "http2")]
+                Err(Error::H2(crate::h2::Error::H2(err))) => {
+                    if !err.is_go_away() {
+                        return Err(Error::H2(crate::h2::Error::H2(err)));
+                    }
+
+                    let reason = err.reason().unwrap();
+
+                    if reason != h2::Reason::NO_ERROR {
+                        return Err(Error::H2(crate::h2::Error::H2(err)));
+                    }
+                }
+                #[cfg(feature = "http2")]
+                Err(Error::H2(crate::h2::Error::Io(err))) => {
+                    if err.kind() != io::ErrorKind::UnexpectedEof {
+                        return Err(Error::H2(crate::h2::Error::Io(err)));
+                    }
+                }
+                #[cfg(feature = "http3")]
+                Err(Error::H3(crate::h3::Error::Io(err))) => {
+                    if err.kind() != io::ErrorKind::UnexpectedEof {
+                        return Err(Error::H3(crate::h3::Error::Io(err)));
+                    }
+                }
+                res => return res,
+            }
+
+            *req.uri_mut() = uri.clone();
+            *req.method_mut() = method.clone();
+            *req.headers_mut() = headers.clone();
+        }
+    }
+}

--- a/client/src/response.rs
+++ b/client/src/response.rs
@@ -177,8 +177,8 @@ impl<const PAYLOAD_LIMIT: usize> Response<PAYLOAD_LIMIT> {
     /// Public API for test purpose.
     ///
     /// Used for testing server implementation to make sure it follows spec.
-    pub fn can_close_connection(&mut self) -> bool {
-        self.res.body_mut().can_destroy_on_drop()
+    pub fn can_close_connection(&self) -> bool {
+        self.res.body().can_destroy_on_drop()
     }
 }
 

--- a/test/tests/h2.rs
+++ b/test/tests/h2.rs
@@ -20,7 +20,7 @@ async fn h2_get() -> Result<(), Error> {
     let c = Client::new();
 
     for _ in 0..3 {
-        let mut res = c.get(&server_url).version(Version::HTTP_2).send().await?;
+        let res = c.get(&server_url).version(Version::HTTP_2).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let body = res.string().await?;
@@ -46,7 +46,7 @@ async fn h2_no_host_header() -> Result<(), Error> {
         let mut req = c.get(&server_url).version(Version::HTTP_2);
         req.headers_mut().insert(header::HOST, "localhost".parse().unwrap());
 
-        let mut res = req.send().await?;
+        let res = req.send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let body = res.string().await?;
@@ -73,7 +73,7 @@ async fn h2_post() -> Result<(), Error> {
         for _ in 0..1024 * 1024 {
             body.extend_from_slice(b"Hello,World!");
         }
-        let mut res = c.post(&server_url).version(Version::HTTP_2).text(body).send().await?;
+        let res = c.post(&server_url).version(Version::HTTP_2).text(body).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let _ = res.body().await;
@@ -142,7 +142,7 @@ async fn h2_keepalive() -> Result<(), Error> {
             .block_on(async move {
                 let c = Client::new();
 
-                let mut res = c.get(&server_url).version(Version::HTTP_2).send().await?;
+                let res = c.get(&server_url).version(Version::HTTP_2).send().await?;
                 assert_eq!(res.status().as_u16(), 200);
                 assert!(!res.can_close_connection());
                 let body = res.string().await?;

--- a/test/tests/h3.rs
+++ b/test/tests/h3.rs
@@ -17,7 +17,7 @@ async fn h3_get() -> Result<(), Error> {
     let server_url = format!("https://localhost:{}/", handle.addr().port());
 
     for _ in 0..3 {
-        let mut res = c.get(&server_url).version(Version::HTTP_3).send().await?;
+        let res = c.get(&server_url).version(Version::HTTP_3).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let body = res.string().await?;
@@ -43,7 +43,7 @@ async fn h3_no_host_header() -> Result<(), Error> {
         let mut req = c.get(&server_url).version(Version::HTTP_3);
         req.headers_mut().insert(header::HOST, "localhost".parse().unwrap());
 
-        let mut res = req.send().await?;
+        let res = req.send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
         let body = res.string().await?;
@@ -70,7 +70,7 @@ async fn h3_post() -> Result<(), Error> {
         for _ in 0..1024 * 1024 {
             body.extend_from_slice(b"Hello,World!");
         }
-        let mut res = c.post(&server_url).version(Version::HTTP_3).text(body).send().await?;
+        let res = c.post(&server_url).version(Version::HTTP_3).text(body).send().await?;
         assert_eq!(res.status().as_u16(), 200);
         assert!(!res.can_close_connection());
     }


### PR DESCRIPTION
When using client with a http1 server, if connection is closed by server we should retry to acquire a new connection instead of throwing an error.

Add a test to verify this behavior and fix the code, i had to clone the connect url in order for this to work, but maybe there is a better way ?