### PR TITLE
fix(client): drop connection if body of a response was not consumed, to avoid bad state

### DIFF
--- a/client/src/body.rs
+++ b/client/src/body.rs
@@ -20,9 +20,7 @@ use crate::bytes::Bytes;
 #[allow(clippy::large_enum_variant)]
 pub enum ResponseBody {
     #[cfg(feature = "http1")]
-    H1(crate::h1::body::ResponseBody<crate::connection::H1ConnectionWithKey>),
-    #[cfg(feature = "http1")]
-    H1Owned(crate::h1::body::ResponseBody<crate::connection::H1ConnectionWithoutKey>),
+    H1(crate::h1::body::ResponseBody),
     #[cfg(feature = "http2")]
     H2(crate::h2::body::ResponseBody),
     #[cfg(feature = "http3")]
@@ -36,8 +34,6 @@ impl fmt::Debug for ResponseBody {
         match *self {
             #[cfg(feature = "http1")]
             Self::H1(_) => f.write_str("ResponseBody::H1(..)"),
-            #[cfg(feature = "http1")]
-            Self::H1Owned(_) => f.write_str("ResponseBody::H1Owned(..)"),
             #[cfg(feature = "http2")]
             Self::H2(_) => f.write_str("ResponseBody::H2(..)"),
             #[cfg(feature = "http3")]
@@ -73,8 +69,6 @@ impl Stream for ResponseBody {
         match self.get_mut() {
             #[cfg(feature = "http1")]
             Self::H1(body) => Pin::new(body).poll_next(cx),
-            #[cfg(feature = "http1")]
-            Self::H1Owned(body) => Pin::new(body).poll_next(cx),
             #[cfg(feature = "http2")]
             Self::H2(body) => Pin::new(body).poll_next(cx),
             #[cfg(feature = "http3")]

--- a/client/src/connection.rs
+++ b/client/src/connection.rs
@@ -4,14 +4,6 @@ use xitca_http::http::uri::{Authority, PathAndQuery};
 
 use super::{tls::TlsStream, uri::Uri};
 
-#[cfg(feature = "http1")]
-/// A convince type alias for typing connection without interacting with pool.
-pub type H1ConnectionWithKey = crate::pool::exclusive::Conn<ConnectionKey, ConnectionExclusive>;
-
-#[cfg(feature = "http1")]
-/// A convince type alias for typing connection without interacting with pool.
-pub type H1ConnectionWithoutKey = crate::pool::exclusive::PooledConn<ConnectionExclusive>;
-
 /// exclusive connection for http1 and in certain case they can be upgraded to [ConnectionShared]
 pub type ConnectionExclusive = TlsStream;
 

--- a/client/src/h1/body.rs
+++ b/client/src/h1/body.rs
@@ -1,6 +1,5 @@
 use std::{
     io,
-    ops::DerefMut,
     pin::Pin,
     task::{ready, Context, Poll},
 };
@@ -11,33 +10,36 @@ use xitca_http::{
     error::BodyError,
     h1::proto::codec::{ChunkResult, TransferCoding},
 };
-use xitca_io::io::{AsyncIo, Interest};
+use xitca_io::io::Interest;
 
-pub struct ResponseBody<C> {
-    conn: C,
+use crate::{
+    connection::{ConnectionExclusive, ConnectionKey},
+    pool::exclusive::Conn,
+};
+
+pub type Connection = Conn<ConnectionKey, ConnectionExclusive>;
+
+pub struct ResponseBody {
+    conn: Connection,
     buf: BytesMut,
     decoder: TransferCoding,
 }
 
-impl<C> ResponseBody<C> {
-    pub(crate) fn new(conn: C, buf: BytesMut, decoder: TransferCoding) -> Self {
+impl ResponseBody {
+    pub(crate) fn new(conn: Connection, buf: BytesMut, decoder: TransferCoding) -> Self {
         Self { conn, buf, decoder }
     }
 
-    pub(crate) fn conn(&self) -> &C {
+    pub(crate) fn conn(&self) -> &Connection {
         &self.conn
     }
 
-    pub(crate) fn conn_mut(&mut self) -> &mut C {
+    pub(crate) fn conn_mut(&mut self) -> &mut Connection {
         &mut self.conn
     }
 }
 
-impl<C> Stream for ResponseBody<C>
-where
-    C: DerefMut + Unpin,
-    C::Target: AsyncIo + Sized,
-{
+impl Stream for ResponseBody {
     type Item = Result<Bytes, BodyError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -66,6 +68,14 @@ where
                 ChunkResult::Err(e) => return Poll::Ready(Some(Err(e.into()))),
                 _ => return Poll::Ready(None),
             }
+        }
+    }
+}
+
+impl Drop for ResponseBody {
+    fn drop(&mut self) {
+        if !self.decoder.is_eof() {
+            self.conn.destroy_on_drop()
         }
     }
 }

--- a/client/src/ws.rs
+++ b/client/src/ws.rs
@@ -113,8 +113,6 @@ impl Sink<Message> for WebSocketTunnel {
         let _io: &mut ConnectionExclusive = match inner.recv_stream.inner_mut() {
             #[cfg(feature = "http1")]
             ResponseBody::H1(body) => body.conn_mut(),
-            #[cfg(feature = "http1")]
-            ResponseBody::H1Owned(body) => body.conn_mut(),
             #[cfg(feature = "http2")]
             ResponseBody::H2(body) => {
                 while !inner.send_buf.chunk().is_empty() {
@@ -158,10 +156,6 @@ impl Sink<Message> for WebSocketTunnel {
         match self.get_mut().recv_stream.inner_mut() {
             #[cfg(feature = "http1")]
             ResponseBody::H1(body) => {
-                xitca_io::io::AsyncIo::poll_shutdown(Pin::new(&mut **body.conn_mut()), cx).map_err(Into::into)
-            }
-            #[cfg(feature = "http1")]
-            ResponseBody::H1Owned(body) => {
                 xitca_io::io::AsyncIo::poll_shutdown(Pin::new(&mut **body.conn_mut()), cx).map_err(Into::into)
             }
             #[cfg(feature = "http2")]


### PR DESCRIPTION
Pr is not finished, i only added a test.

Actually if a body is not readed on the client, but the reponse is dropped, conn will go back to the pool with existing data of the response not consumed, which will fail the next request since it will try to decode the header on the previous response body

This may happens if a client send a request, gets an error with a status code and a message in the body by example, and when there is a specific status code (in this case the error), will not bother to consume the body.

Not sure how to handle this well, i assume we should force the body to be consumed before going back to the pool but i'm not sure how to do this 