### PR TITLE
feat(client): allow to add a closure as a middleware in client

### DIFF
--- a/client/src/middleware/async_fn.rs
+++ b/client/src/middleware/async_fn.rs
@@ -1,0 +1,33 @@
+use crate::{
+    error::Error,
+    response::Response,
+    service::{async_fn, Service, ServiceRequest},
+};
+
+/// middleware to wrap async function as a service.
+pub struct AsyncFn<S, F> {
+    service: S,
+    func: F,
+}
+
+impl<S, F> AsyncFn<S, F> {
+    pub fn new(service: S, func: F) -> Self {
+        Self { service, func }
+    }
+}
+
+impl<'r, 'c, S, F> Service<ServiceRequest<'r, 'c>> for AsyncFn<S, F>
+where
+    S: for<'r2, 'c2> Service<ServiceRequest<'r, 'c>, Response = Response, Error = Error> + Send + Sync,
+    F: for<'r3, 'c3, 's3> async_fn::AsyncFn<(ServiceRequest<'r, 'c>, &'s3 S), Output = Result<Response, Error>>
+        + Send
+        + Sync,
+    for<'r4, 'c4, 's4> <F as async_fn::AsyncFn<(ServiceRequest<'r4, 'c4>, &'s4 S)>>::Future: Send,
+{
+    type Response = Response;
+    type Error = Error;
+
+    async fn call(&self, req: ServiceRequest<'r, 'c>) -> Result<Self::Response, Self::Error> {
+        self.func.call((req, &self.service)).await
+    }
+}

--- a/client/src/middleware/mod.rs
+++ b/client/src/middleware/mod.rs
@@ -2,10 +2,12 @@
 
 mod redirect;
 
+mod async_fn;
 #[cfg(feature = "compress")]
 mod decompress;
 
 #[cfg(feature = "compress")]
 pub use decompress::Decompress;
 
+pub(crate) use async_fn::AsyncFn;
 pub use redirect::FollowRedirect;

--- a/client/src/service/async_fn.rs
+++ b/client/src/service/async_fn.rs
@@ -1,0 +1,44 @@
+#![allow(non_snake_case)]
+
+use core::future::Future;
+
+/// Same as `std::ops::Fn` trait but for async output.
+///
+/// It is necessary in the the HRTB bounds for async fn's with reference parameters because it
+/// allows the output future to be bound to the parameter lifetime.
+///     `F: for<'a> AsyncFn<(&'a u8,) Output=u8>`
+pub trait AsyncFn<Arg> {
+    type Output;
+    type Future: Future<Output = Self::Output>;
+
+    fn call(&self, arg: Arg) -> Self::Future;
+}
+
+macro_rules! async_closure_impl {
+    ($($arg: ident),*) => {
+        impl<Func, Fut, $($arg,)*> AsyncFn<($($arg,)*)> for Func
+        where
+            Func: Fn($($arg),*) -> Fut,
+            Fut: Future,
+        {
+            type Output = Fut::Output;
+            type Future = Fut;
+
+            #[inline]
+            fn call(&self, ($($arg,)*): ($($arg,)*)) -> Self::Future {
+                self($($arg,)*)
+            }
+        }
+    }
+}
+
+async_closure_impl! {}
+async_closure_impl! { A }
+async_closure_impl! { A, B }
+async_closure_impl! { A, B, C }
+async_closure_impl! { A, B, C, D }
+async_closure_impl! { A, B, C, D, E }
+async_closure_impl! { A, B, C, D, E, F }
+async_closure_impl! { A, B, C, D, E, F, G }
+async_closure_impl! { A, B, C, D, E, F, G, H }
+async_closure_impl! { A, B, C, D, E, F, G, H, I }

--- a/client/src/service/http.rs
+++ b/client/src/service/http.rs
@@ -1,74 +1,13 @@
-use core::{future::Future, pin::Pin, time::Duration};
-
 use crate::{
-    body::BoxBody,
-    client::Client,
     connect::Connect,
     error::Error,
-    http::{Request, Version},
+    http::Version,
     pool::{exclusive, shared},
     response::Response,
+    service::ServiceDyn,
     uri::Uri,
+    Service, ServiceRequest,
 };
-
-type BoxFuture<'f, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'f>>;
-
-/// trait for composable http services. Used for middleware,resolver and tls connector.
-pub trait Service<Req> {
-    type Response;
-    type Error;
-
-    fn call(&self, req: Req) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send;
-}
-
-pub trait ServiceDyn<Req> {
-    type Response;
-    type Error;
-
-    fn call<'s>(&'s self, req: Req) -> BoxFuture<'s, Self::Response, Self::Error>
-    where
-        Req: 's;
-}
-
-impl<S, Req> ServiceDyn<Req> for S
-where
-    S: Service<Req>,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-
-    #[inline]
-    fn call<'s>(&'s self, req: Req) -> BoxFuture<'s, Self::Response, Self::Error>
-    where
-        Req: 's,
-    {
-        Box::pin(Service::call(self, req))
-    }
-}
-
-impl<I, Req> Service<Req> for Box<I>
-where
-    Req: Send,
-    I: ServiceDyn<Req> + ?Sized + Send + Sync,
-{
-    type Response = I::Response;
-    type Error = I::Error;
-
-    #[inline]
-    async fn call(&self, req: Req) -> Result<Self::Response, Self::Error> {
-        ServiceDyn::call(&**self, req).await
-    }
-}
-
-/// request type for middlewares.
-/// It's similar to [RequestBuilder] type but with additional side effect enabled.
-///
-/// [RequestBuilder]: crate::request::RequestBuilder
-pub struct ServiceRequest<'r, 'c> {
-    pub req: &'r mut Request<BoxBody>,
-    pub client: &'c Client,
-    pub timeout: Duration,
-}
 
 /// type alias for object safe wrapper of type implement [Service] trait.
 pub type HttpService =
@@ -261,73 +200,4 @@ pub(crate) fn base_service() -> HttpService {
     }
 
     Box::new(HttpService)
-}
-
-#[cfg(test)]
-pub(crate) use test::mock_service;
-
-#[cfg(test)]
-mod test {
-    use core::time::Duration;
-
-    use std::sync::Arc;
-
-    use crate::{
-        body::{BoxBody, ResponseBody},
-        client::Client,
-        error::Error,
-        http::{self, Request},
-        response::Response,
-        service::{Service, ServiceRequest},
-    };
-
-    // http service and it's handle to make http service where a request and it's server side handler logic
-    // is mocked on client side.
-    pub(crate) fn mock_service() -> (HttpServiceMockHandle, HttpServiceMock) {
-        (HttpServiceMockHandle(Client::new()), HttpServiceMock { _p: () })
-    }
-
-    pub(crate) struct HttpServiceMock {
-        _p: (),
-    }
-
-    pub(crate) struct HttpServiceMockHandle(Client);
-
-    type HandlerFn = Arc<dyn Fn(Request<BoxBody>) -> Result<http::Response<ResponseBody>, Error> + Send + Sync>;
-
-    impl HttpServiceMockHandle {
-        /// compose a service request with given http request and it's mocked server side handler function
-        pub(crate) fn mock<'r, 'c>(
-            &'c self,
-            req: &'r mut Request<BoxBody>,
-            handler: impl Fn(Request<BoxBody>) -> Result<http::Response<ResponseBody>, Error> + Send + Sync + 'static,
-        ) -> ServiceRequest<'r, 'c> {
-            req.extensions_mut().insert(Arc::new(handler) as HandlerFn);
-            ServiceRequest {
-                req,
-                client: &self.0,
-                timeout: self.0.timeout_config.request_timeout,
-            }
-        }
-    }
-
-    impl<'r, 'c> Service<ServiceRequest<'r, 'c>> for HttpServiceMock {
-        type Response = Response;
-        type Error = Error;
-
-        async fn call(
-            &self,
-            ServiceRequest { req, timeout, .. }: ServiceRequest<'r, 'c>,
-        ) -> Result<Self::Response, Self::Error> {
-            let handler = req.extensions().get::<HandlerFn>().unwrap().clone();
-
-            let res = handler(core::mem::take(req))?;
-
-            Ok(Response::new(
-                res,
-                Box::pin(tokio::time::sleep(Duration::from_secs(0))),
-                timeout,
-            ))
-        }
-    }
 }

--- a/client/src/service/mod.rs
+++ b/client/src/service/mod.rs
@@ -1,0 +1,135 @@
+pub(crate) mod async_fn;
+pub(crate) mod http;
+
+use core::{future::Future, pin::Pin, time::Duration};
+
+use crate::{body::BoxBody, client::Client, http::Request};
+pub use http::HttpService;
+
+type BoxFuture<'f, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'f>>;
+
+/// trait for composable http services. Used for middleware,resolver and tls connector.
+pub trait Service<Req> {
+    type Response;
+    type Error;
+
+    fn call(&self, req: Req) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send;
+}
+
+pub trait ServiceDyn<Req> {
+    type Response;
+    type Error;
+
+    fn call<'s>(&'s self, req: Req) -> BoxFuture<'s, Self::Response, Self::Error>
+    where
+        Req: 's;
+}
+
+impl<S, Req> ServiceDyn<Req> for S
+where
+    S: Service<Req>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+
+    #[inline]
+    fn call<'s>(&'s self, req: Req) -> BoxFuture<'s, Self::Response, Self::Error>
+    where
+        Req: 's,
+    {
+        Box::pin(Service::call(self, req))
+    }
+}
+
+impl<I, Req> Service<Req> for Box<I>
+where
+    Req: Send,
+    I: ServiceDyn<Req> + ?Sized + Send + Sync,
+{
+    type Response = I::Response;
+    type Error = I::Error;
+
+    #[inline]
+    async fn call(&self, req: Req) -> Result<Self::Response, Self::Error> {
+        ServiceDyn::call(&**self, req).await
+    }
+}
+
+/// request type for middlewares.
+/// It's similar to [RequestBuilder] type but with additional side effect enabled.
+///
+/// [RequestBuilder]: crate::request::RequestBuilder
+pub struct ServiceRequest<'r, 'c> {
+    pub req: &'r mut Request<BoxBody>,
+    pub client: &'c Client,
+    pub timeout: Duration,
+}
+
+#[cfg(test)]
+pub(crate) use test::mock_service;
+
+#[cfg(test)]
+mod test {
+    use core::time::Duration;
+
+    use std::sync::Arc;
+
+    use crate::{
+        body::{BoxBody, ResponseBody},
+        client::Client,
+        error::Error,
+        http::{self, Request},
+        response::Response,
+        service::{Service, ServiceRequest},
+    };
+
+    // http service and it's handle to make http service where a request and it's server side handler logic
+    // is mocked on client side.
+    pub(crate) fn mock_service() -> (HttpServiceMockHandle, HttpServiceMock) {
+        (HttpServiceMockHandle(Client::new()), HttpServiceMock { _p: () })
+    }
+
+    pub(crate) struct HttpServiceMock {
+        _p: (),
+    }
+
+    pub(crate) struct HttpServiceMockHandle(Client);
+
+    type HandlerFn = Arc<dyn Fn(Request<BoxBody>) -> Result<http::Response<ResponseBody>, Error> + Send + Sync>;
+
+    impl HttpServiceMockHandle {
+        /// compose a service request with given http request and it's mocked server side handler function
+        pub(crate) fn mock<'r, 'c>(
+            &'c self,
+            req: &'r mut Request<BoxBody>,
+            handler: impl Fn(Request<BoxBody>) -> Result<http::Response<ResponseBody>, Error> + Send + Sync + 'static,
+        ) -> ServiceRequest<'r, 'c> {
+            req.extensions_mut().insert(Arc::new(handler) as HandlerFn);
+            ServiceRequest {
+                req,
+                client: &self.0,
+                timeout: self.0.timeout_config.request_timeout,
+            }
+        }
+    }
+
+    impl<'r, 'c> Service<ServiceRequest<'r, 'c>> for HttpServiceMock {
+        type Response = Response;
+        type Error = Error;
+
+        async fn call(
+            &self,
+            ServiceRequest { req, timeout, .. }: ServiceRequest<'r, 'c>,
+        ) -> Result<Self::Response, Self::Error> {
+            let handler = req.extensions().get::<HandlerFn>().unwrap().clone();
+
+            let res = handler(core::mem::take(req))?;
+
+            Ok(Response::new(
+                res,
+                Box::pin(tokio::time::sleep(Duration::from_secs(0))),
+                timeout,
+            ))
+        }
+    }
+}


### PR DESCRIPTION
Ref https://github.com/HFQR/xitca-web/pull/1181

This PR allow an user to pass a closure as a middleware.

