### PR TITLE
feat(server): allow to implement AsListener for external lib

### DIFF
--- a/server/src/net/mod.rs
+++ b/server/src/net/mod.rs
@@ -15,6 +15,17 @@ pub trait AsListener: Send {
     fn as_listener(&mut self) -> io::Result<Listener>;
 }
 
+impl<T> AsListener for Option<T>
+where
+    T: AsListener,
+{
+    fn as_listener(&mut self) -> io::Result<Listener> {
+        let mut this = self.take().unwrap();
+
+        this.as_listener()
+    }
+}
+
 impl AsListener for Option<net::TcpListener> {
     fn as_listener(&mut self) -> io::Result<Listener> {
         let this = self.take().unwrap();


### PR DESCRIPTION
I was trying to build a h3 server from an existing udp socket, i managed to correctly build quic endpoint but was not able to transform this endpoint for xitca.

With this feature this is possible (as i have just to impl this trait from a owned typed)