### PR TITLE
chore(clippy): fix clippy errors

### DIFF
--- a/.github/workflows/clippy-fmt.yml
+++ b/.github/workflows/clippy-fmt.yml
@@ -15,6 +15,6 @@ jobs:
         components: clippy, rustfmt
     - uses: Swatinem/rust-cache@v2
     - name: clippy
-      run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      run: cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::literal_string_with_formatting_args
     - name: fmt
       run: cargo fmt --all --check

--- a/http/src/h2/proto/hpack/encoder.rs
+++ b/http/src/h2/proto/hpack/encoder.rs
@@ -323,7 +323,7 @@ mod test {
 
         let res = encode(&mut encoder, vec![method("PATCH")]);
 
-        assert_eq!(1 << 7 | 62, res[0]);
+        assert_eq!((1 << 7) | 62, res[0]);
         assert_eq!(1, res.len());
     }
 

--- a/http/src/tls/openssl.rs
+++ b/http/src/tls/openssl.rs
@@ -57,7 +57,7 @@ impl TlsAcceptorService {
     async fn accept<Io: AsyncIo>(&self, io: Io) -> Result<TlsStream<Io>, OpensslError> {
         let ctx = self.acceptor.context();
         let ssl = ssl::Ssl::new(ctx)?;
-        TlsStream::accept(ssl, io).await.map_err(Into::into)
+        TlsStream::accept(ssl, io).await
     }
 }
 


### PR DESCRIPTION
This should make ci green again, i was waiting on https://github.com/rust-lang/rust-clippy/pull/13953 to be merge but it seems this will take longer than expected to have it working, 