### PR TITLE
feat(h2): use a more reasonable timer for keep alive timeout in h2

### DIFF
--- a/http/src/h2/service.rs
+++ b/http/src/h2/service.rs
@@ -59,6 +59,7 @@ where
             addr,
             timer,
             self.config.keep_alive_timeout,
+            self.config.keep_alive_timeout,
             &self.service,
             self.date.get(),
         );

--- a/http/src/service.rs
+++ b/http/src/service.rs
@@ -140,6 +140,7 @@ where
                             _addr,
                             timer.as_mut(),
                             self.config.keep_alive_timeout,
+                            self.config.keep_alive_timeout,
                             &self.service,
                             self.date.get(),
                         )


### PR DESCRIPTION
I was looking at why the keep alive h2 test was running for so long (5 sec)
and this was the `* 10` mult on duration that was causing this.

I'm not sure this a good default, and maybe it should be configurable, in fact in h2, it may need 2 different duration configurable: 

* keep_alive_idle_timeout : which is the duration to wait to launch keep alive (ping pong) check after no more requests are received (it's the current value of keep_alive_timeout)
* keep_alive_timeout : which is the duration to wait for a ping pong response from the client (currently equal to keep_alive_timeout * 10 - keep_alive_timeout)