### PR TITLE
feat(http): expose tls mod and add custom error to allow using other tls implementation

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -36,8 +36,6 @@
 
 #![forbid(unsafe_code)]
 
-mod tls;
-
 #[cfg(feature = "runtime")]
 mod builder;
 #[cfg(feature = "runtime")]
@@ -49,6 +47,7 @@ pub mod body;
 pub mod config;
 pub mod error;
 pub mod http;
+pub mod tls;
 pub mod util;
 
 #[cfg(feature = "runtime")]

--- a/http/src/tls/error.rs
+++ b/http/src/tls/error.rs
@@ -10,6 +10,7 @@ pub enum TlsError {
     Rustls(super::rustls::RustlsError),
     #[cfg(feature = "native-tls")]
     NativeTls(super::native_tls::NativeTlsError),
+    OtherTls(Box<dyn error::Error + Send + Sync>),
 }
 
 impl fmt::Debug for TlsError {
@@ -22,6 +23,7 @@ impl fmt::Debug for TlsError {
             Self::Rustls(ref e) => fmt::Debug::fmt(e, _f),
             #[cfg(feature = "native-tls")]
             Self::NativeTls(ref e) => fmt::Debug::fmt(e, _f),
+            Self::OtherTls(ref e) => fmt::Debug::fmt(e, _f),
         }
     }
 }
@@ -36,11 +38,18 @@ impl fmt::Display for TlsError {
             Self::Rustls(ref e) => fmt::Debug::fmt(e, _f),
             #[cfg(feature = "native-tls")]
             Self::NativeTls(ref e) => fmt::Display::fmt(e, _f),
+            Self::OtherTls(ref e) => fmt::Display::fmt(e, _f),
         }
     }
 }
 
 impl error::Error for TlsError {}
+
+impl From<Box<dyn error::Error + Send + Sync>> for TlsError {
+    fn from(e: Box<dyn error::Error + Send + Sync>) -> Self {
+        Self::OtherTls(e)
+    }
+}
 
 impl<S, B> From<TlsError> for HttpServiceError<S, B> {
     fn from(e: TlsError) -> Self {


### PR DESCRIPTION
I am currently trying to implement a way to have automatic certificate with acme and xitca and this need to have a specific tls acceptor (to allow lazy config acceptor like it's done in tokio rustls : cf https://tg-rs.github.io/carapax/tokio_rustls/struct.LazyConfigAcceptor.html )

Goal is to make a tls connection waiting when a certificate is being created (so there is no insecure / dropped connection on start)

There is already the `with_tls` method on the HttpServiceBuilder but this need to expose a TlsError which is not public, this PR fix that by making it public and allow any errors in it