### PR TITLE
feat(server): allow custom implementations of listener

### DIFF
--- a/io/src/net.rs
+++ b/io/src/net.rs
@@ -106,16 +106,6 @@ macro_rules! default_aio_impl {
 
 use default_aio_impl;
 
-/// A collection of listener types of different protocol.
-#[derive(Debug)]
-pub enum Listener {
-    Tcp(TcpListener),
-    #[cfg(feature = "quic")]
-    Udp(QuicListener),
-    #[cfg(unix)]
-    Unix(UnixListener),
-}
-
 type BoxFuture<'f, T> = Pin<Box<dyn Future<Output = T> + Send + 'f>>;
 
 pub trait Listen {
@@ -125,8 +115,6 @@ pub trait Listen {
 pub trait ListenDyn {
     fn accept(&self) -> BoxFuture<io::Result<Stream>>;
 }
-
-pub type ListenObj = Box<dyn ListenDyn + Send + Sync>;
 
 impl<S> ListenDyn for S
 where
@@ -148,28 +136,30 @@ where
     }
 }
 
-impl Listen for Listener {
+impl Listen for TcpListener {
     async fn accept(&self) -> io::Result<Stream> {
-        match *self {
-            Self::Tcp(ref tcp) => {
-                let (stream, addr) = tcp.accept().await?;
-                let stream = stream.into_std()?;
-                Ok(Stream::Tcp(stream, addr))
-            }
-            #[cfg(feature = "quic")]
-            Self::Udp(ref udp) => {
-                let stream = udp.accept().await?;
-                let addr = stream.peer_addr();
-                Ok(Stream::Udp(stream, addr))
-            }
-            #[cfg(unix)]
-            Self::Unix(ref unix) => {
-                let (stream, _) = unix.accept().await?;
-                let stream = stream.into_std()?;
-                let addr = stream.peer_addr()?;
-                Ok(Stream::Unix(stream, addr))
-            }
-        }
+        let (stream, addr) = self.accept().await?;
+        let stream = stream.into_std()?;
+        Ok(Stream::Tcp(stream, addr))
+    }
+}
+
+#[cfg(feature = "quic")]
+impl Listen for QuicListener {
+    async fn accept(&self) -> io::Result<Stream> {
+        let stream = self.accept().await?;
+        let addr = stream.peer_addr();
+        Ok(Stream::Udp(stream, addr))
+    }
+}
+
+#[cfg(unix)]
+impl Listen for UnixListener {
+    async fn accept(&self) -> io::Result<Stream> {
+        let (stream, _) = self.accept().await?;
+        let stream = stream.into_std()?;
+        let addr = stream.peer_addr()?;
+        Ok(Stream::Unix(stream, addr))
     }
 }
 

--- a/io/src/net.rs
+++ b/io/src/net.rs
@@ -127,16 +127,6 @@ where
     }
 }
 
-impl<I> Listen for Box<I>
-where
-    I: ListenDyn + ?Sized + Send + Sync,
-{
-    #[inline]
-    async fn accept(&self) -> io::Result<Stream> {
-        ListenDyn::accept(&**self).await
-    }
-}
-
 impl Listen for TcpListener {
     async fn accept(&self) -> io::Result<Stream> {
         let (stream, addr) = self.accept().await?;

--- a/io/src/net.rs
+++ b/io/src/net.rs
@@ -108,11 +108,12 @@ use default_aio_impl;
 
 type BoxFuture<'f, T> = Pin<Box<dyn Future<Output = T> + Send + 'f>>;
 
-pub trait Listen {
+pub trait Listen: Send + Sync {
     fn accept(&self) -> impl Future<Output = io::Result<Stream>> + Send;
 }
 
-pub trait ListenDyn {
+#[doc(hidden)]
+pub trait ListenDyn: Send + Sync {
     fn accept(&self) -> BoxFuture<io::Result<Stream>>;
 }
 

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -3,10 +3,10 @@ use std::{collections::HashMap, future::Future, io, pin::Pin, time::Duration};
 #[cfg(not(target_family = "wasm"))]
 use std::net;
 
-use xitca_io::net::{ListenObj, Stream};
+use xitca_io::net::Stream;
 
 use crate::{
-    net::IntoListener,
+    net::{IntoListener, ListenObj},
     server::{IntoServiceObj, Server, ServerFuture, ServiceObj},
 };
 

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -3,14 +3,16 @@ use std::{collections::HashMap, future::Future, io, pin::Pin, time::Duration};
 #[cfg(not(target_family = "wasm"))]
 use std::net;
 
-use xitca_io::net::Stream;
+use std::sync::Arc;
+
+use xitca_io::net::{ListenDyn, Stream};
 
 use crate::{
-    net::{IntoListener, ListenObj},
+    net::IntoListener,
     server::{IntoServiceObj, Server, ServerFuture, ServiceObj},
 };
 
-type ListenerFn = Box<dyn FnOnce() -> io::Result<ListenObj> + Send>;
+type ListenerFn = Box<dyn FnOnce() -> io::Result<Arc<dyn ListenDyn>> + Send>;
 
 pub struct Builder {
     pub(crate) server_threads: usize,
@@ -143,7 +145,9 @@ impl Builder {
         self.listeners
             .entry(name.as_ref().to_string())
             .or_default()
-            .push(Box::new(|| listener.into_listener()));
+            .push(Box::new(|| {
+                listener.into_listener().map(|l| Arc::new(l) as Arc<dyn ListenDyn>)
+            }));
 
         self.factories.insert(name.as_ref().to_string(), service.into_object());
 
@@ -241,10 +245,9 @@ impl Builder {
 
         let builder = xitca_io::net::QuicListenerBuilder::new(addr, config).backlog(self.backlog);
 
-        self.listeners
-            .get_mut(name.as_ref())
-            .unwrap()
-            .push(Box::new(|| builder.into_listener()));
+        self.listeners.get_mut(name.as_ref()).unwrap().push(Box::new(|| {
+            builder.into_listener().map(|l| Arc::new(l) as Arc<dyn ListenDyn>)
+        }));
 
         Ok(self)
     }

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -3,14 +3,14 @@ use std::{collections::HashMap, future::Future, io, pin::Pin, time::Duration};
 #[cfg(not(target_family = "wasm"))]
 use std::net;
 
-use xitca_io::net::{Listener, Stream};
+use xitca_io::net::{ListenObj, Stream};
 
 use crate::{
     net::IntoListener,
     server::{IntoServiceObj, Server, ServerFuture, ServiceObj},
 };
 
-type ListenerFn = Box<dyn FnOnce() -> io::Result<Listener> + Send>;
+type ListenerFn = Box<dyn FnOnce() -> io::Result<ListenObj> + Send>;
 
 pub struct Builder {
     pub(crate) server_threads: usize,

--- a/server/src/net/mod.rs
+++ b/server/src/net/mod.rs
@@ -4,40 +4,40 @@ use std::io;
 use xitca_io::net::QuicListenerBuilder;
 #[cfg(unix)]
 use xitca_io::net::UnixListener;
-use xitca_io::net::{Listener, TcpListener};
+use xitca_io::net::{ListenObj, Listener, TcpListener};
 
 use tracing::info;
 
 /// Helper trait for converting listener types and register them to xitca-server
 /// By delay the conversion and make the process happen in server thread(s) it avoid possible panic due to runtime locality.
 pub trait IntoListener: Send {
-    fn into_listener(self) -> io::Result<Listener>;
+    fn into_listener(self) -> io::Result<ListenObj>;
 }
 
 impl IntoListener for std::net::TcpListener {
-    fn into_listener(self) -> io::Result<Listener> {
+    fn into_listener(self) -> io::Result<ListenObj> {
         self.set_nonblocking(true)?;
         let listener = TcpListener::from_std(self)?;
         info!("Started Tcp listening on: {:?}", listener.local_addr().ok());
-        Ok(Listener::Tcp(listener))
+        Ok(Box::new(Listener::Tcp(listener)))
     }
 }
 
 #[cfg(unix)]
 impl IntoListener for std::os::unix::net::UnixListener {
-    fn into_listener(self) -> io::Result<Listener> {
+    fn into_listener(self) -> io::Result<ListenObj> {
         self.set_nonblocking(true)?;
         let listener = UnixListener::from_std(self)?;
         info!("Started Unix listening on: {:?}", listener.local_addr().ok());
-        Ok(Listener::Unix(listener))
+        Ok(Box::new(Listener::Unix(listener)))
     }
 }
 
 #[cfg(feature = "quic")]
 impl IntoListener for QuicListenerBuilder {
-    fn into_listener(self) -> io::Result<Listener> {
+    fn into_listener(self) -> io::Result<ListenObj> {
         let udp = self.build()?;
         info!("Started Udp listening on: {:?}", udp.endpoint().local_addr().ok());
-        Ok(Listener::Udp(udp))
+        Ok(Box::new(Listener::Udp(udp)))
     }
 }

--- a/server/src/net/mod.rs
+++ b/server/src/net/mod.rs
@@ -1,45 +1,51 @@
-use std::{io, sync::Arc};
+use std::io;
 
 #[cfg(feature = "quic")]
-use xitca_io::net::QuicListenerBuilder;
+use xitca_io::net::{QuicListener, QuicListenerBuilder};
 #[cfg(unix)]
 use xitca_io::net::UnixListener;
-use xitca_io::net::{ListenDyn, TcpListener};
+use xitca_io::net::{Listen, TcpListener};
 
 use tracing::info;
-
-pub type ListenObj = Arc<dyn ListenDyn + Send + Sync>;
 
 /// Helper trait for converting listener types and register them to xitca-server
 /// By delay the conversion and make the process happen in server thread(s) it avoid possible panic due to runtime locality.
 pub trait IntoListener: Send {
-    fn into_listener(self) -> io::Result<ListenObj>;
+    type Listener: Listen;
+
+    fn into_listener(self) -> io::Result<Self::Listener>;
 }
 
 impl IntoListener for std::net::TcpListener {
-    fn into_listener(self) -> io::Result<ListenObj> {
+    type Listener = TcpListener;
+
+    fn into_listener(self) -> io::Result<Self::Listener> {
         self.set_nonblocking(true)?;
         let listener = TcpListener::from_std(self)?;
         info!("Started Tcp listening on: {:?}", listener.local_addr().ok());
-        Ok(Arc::new(listener))
+        Ok(listener)
     }
 }
 
 #[cfg(unix)]
 impl IntoListener for std::os::unix::net::UnixListener {
-    fn into_listener(self) -> io::Result<ListenObj> {
+    type Listener = UnixListener;
+
+    fn into_listener(self) -> io::Result<Self::Listener> {
         self.set_nonblocking(true)?;
         let listener = UnixListener::from_std(self)?;
         info!("Started Unix listening on: {:?}", listener.local_addr().ok());
-        Ok(Arc::new(listener))
+        Ok(listener)
     }
 }
 
 #[cfg(feature = "quic")]
 impl IntoListener for QuicListenerBuilder {
-    fn into_listener(self) -> io::Result<ListenObj> {
+    type Listener = QuicListener;
+
+    fn into_listener(self) -> io::Result<Self::Listener> {
         let udp = self.build()?;
         info!("Started Udp listening on: {:?}", udp.endpoint().local_addr().ok());
-        Ok(Arc::new(udp))
+        Ok(udp)
     }
 }

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -46,11 +46,7 @@ impl Server {
         let fut = async {
             listeners
                 .into_iter()
-                .flat_map(|(name, listeners)| {
-                    listeners
-                        .into_iter()
-                        .map(move |l| l().map(|l| (name.to_owned(), Arc::new(l))))
-                })
+                .flat_map(|(name, listeners)| listeners.into_iter().map(move |l| l().map(|l| (name.to_owned(), l))))
                 .collect::<Result<Vec<_>, io::Error>>()
         };
 
@@ -108,11 +104,7 @@ impl Server {
         let fut = async {
             listeners
                 .into_iter()
-                .flat_map(|(name, listeners)| {
-                    listeners
-                        .into_iter()
-                        .map(move |l| l().map(|l| (name.to_owned(), Arc::new(l))))
-                })
+                .flat_map(|(name, listeners)| listeners.into_iter().map(move |l| l().map(|l| (name.to_owned(), l))))
                 .collect::<Result<Vec<_>, io::Error>>()
         };
 

--- a/server/src/server/service.rs
+++ b/server/src/server/service.rs
@@ -1,14 +1,17 @@
-use std::{marker::PhantomData, rc::Rc, sync::Arc};
+use std::{marker::PhantomData, rc::Rc};
 
 use tokio::task::JoinHandle;
-use xitca_io::net::{ListenObj, Stream};
+use xitca_io::net::Stream;
 use xitca_service::{Service, ready::ReadyService};
 
-use crate::worker::{self, ServiceAny};
+use crate::{
+    net::ListenObj,
+    worker::{self, ServiceAny},
+};
 
 pub type ServiceObj = Box<
     dyn for<'a> xitca_service::object::ServiceObject<
-            (&'a str, &'a [(String, Arc<ListenObj>)]),
+            (&'a str, &'a [(String, ListenObj)]),
             Response = (Vec<JoinHandle<()>>, ServiceAny),
             Error = (),
         > + Send
@@ -20,7 +23,7 @@ struct Container<F, Req> {
     _t: PhantomData<fn(Req)>,
 }
 
-impl<'a, F, Req> Service<(&'a str, &'a [(String, Arc<ListenObj>)])> for Container<F, Req>
+impl<'a, F, Req> Service<(&'a str, &'a [(String, ListenObj)])> for Container<F, Req>
 where
     F: IntoServiceObj<Req>,
     Req: TryFrom<Stream> + 'static,
@@ -30,7 +33,7 @@ where
 
     async fn call(
         &self,
-        (name, listeners): (&'a str, &'a [(String, Arc<ListenObj>)]),
+        (name, listeners): (&'a str, &'a [(String, ListenObj)]),
     ) -> Result<Self::Response, Self::Error> {
         let service = self.inner.call(()).await.map_err(|_| ())?;
         let service = Rc::new(service);

--- a/server/src/server/service.rs
+++ b/server/src/server/service.rs
@@ -1,14 +1,14 @@
 use std::{marker::PhantomData, rc::Rc, sync::Arc};
 
 use tokio::task::JoinHandle;
-use xitca_io::net::{Listener, Stream};
+use xitca_io::net::{ListenObj, Stream};
 use xitca_service::{Service, ready::ReadyService};
 
 use crate::worker::{self, ServiceAny};
 
 pub type ServiceObj = Box<
     dyn for<'a> xitca_service::object::ServiceObject<
-            (&'a str, &'a [(String, Arc<Listener>)]),
+            (&'a str, &'a [(String, Arc<ListenObj>)]),
             Response = (Vec<JoinHandle<()>>, ServiceAny),
             Error = (),
         > + Send
@@ -20,7 +20,7 @@ struct Container<F, Req> {
     _t: PhantomData<fn(Req)>,
 }
 
-impl<'a, F, Req> Service<(&'a str, &'a [(String, Arc<Listener>)])> for Container<F, Req>
+impl<'a, F, Req> Service<(&'a str, &'a [(String, Arc<ListenObj>)])> for Container<F, Req>
 where
     F: IntoServiceObj<Req>,
     Req: TryFrom<Stream> + 'static,
@@ -30,7 +30,7 @@ where
 
     async fn call(
         &self,
-        (name, listeners): (&'a str, &'a [(String, Arc<Listener>)]),
+        (name, listeners): (&'a str, &'a [(String, Arc<ListenObj>)]),
     ) -> Result<Self::Response, Self::Error> {
         let service = self.inner.call(()).await.map_err(|_| ())?;
         let service = Rc::new(service);

--- a/server/src/worker/mod.rs
+++ b/server/src/worker/mod.rs
@@ -2,21 +2,19 @@ mod shutdown;
 
 use core::{any::Any, sync::atomic::AtomicBool, time::Duration};
 
-use std::{io, rc::Rc, thread};
+use std::{io, rc::Rc, sync::Arc, thread};
 
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{error, info};
-use xitca_io::net::Stream;
+use xitca_io::net::{ListenDyn, Stream};
 use xitca_service::{Service, ready::ReadyService};
-
-use crate::net::ListenObj;
 
 use self::shutdown::ShutdownHandle;
 
 // erase Rc<S: ReadyService<_>> type and only use it for counting the reference counter of Rc.
 pub(crate) type ServiceAny = Rc<dyn Any>;
 
-pub(crate) fn start<S, Req>(listener: &ListenObj, service: &Rc<S>) -> JoinHandle<()>
+pub(crate) fn start<S, Req>(listener: &Arc<dyn ListenDyn>, service: &Rc<S>) -> JoinHandle<()>
 where
     S: ReadyService + Service<Req> + 'static,
     S::Ready: 'static,

--- a/server/src/worker/mod.rs
+++ b/server/src/worker/mod.rs
@@ -6,7 +6,7 @@ use std::{io, rc::Rc, sync::Arc, thread};
 
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{error, info};
-use xitca_io::net::{Listener, Stream};
+use xitca_io::net::{ListenDyn, ListenObj, Stream};
 use xitca_service::{Service, ready::ReadyService};
 
 use self::shutdown::ShutdownHandle;
@@ -14,7 +14,7 @@ use self::shutdown::ShutdownHandle;
 // erase Rc<S: ReadyService<_>> type and only use it for counting the reference counter of Rc.
 pub(crate) type ServiceAny = Rc<dyn Any>;
 
-pub(crate) fn start<S, Req>(listener: &Arc<Listener>, service: &Rc<S>) -> JoinHandle<()>
+pub(crate) fn start<S, Req>(listener: &Arc<ListenObj>, service: &Rc<S>) -> JoinHandle<()>
 where
     S: ReadyService + Service<Req> + 'static,
     S::Ready: 'static,

--- a/server/src/worker/mod.rs
+++ b/server/src/worker/mod.rs
@@ -2,19 +2,21 @@ mod shutdown;
 
 use core::{any::Any, sync::atomic::AtomicBool, time::Duration};
 
-use std::{io, rc::Rc, sync::Arc, thread};
+use std::{io, rc::Rc, thread};
 
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{error, info};
-use xitca_io::net::{ListenDyn, ListenObj, Stream};
+use xitca_io::net::Stream;
 use xitca_service::{Service, ready::ReadyService};
+
+use crate::net::ListenObj;
 
 use self::shutdown::ShutdownHandle;
 
 // erase Rc<S: ReadyService<_>> type and only use it for counting the reference counter of Rc.
 pub(crate) type ServiceAny = Rc<dyn Any>;
 
-pub(crate) fn start<S, Req>(listener: &Arc<ListenObj>, service: &Rc<S>) -> JoinHandle<()>
+pub(crate) fn start<S, Req>(listener: &ListenObj, service: &Rc<S>) -> JoinHandle<()>
 where
     S: ReadyService + Service<Req> + 'static,
     S::Ready: 'static,


### PR DESCRIPTION
Ref https://github.com/HFQR/xitca-web/issues/1190

See this comment : https://github.com/HFQR/xitca-web/issues/1190#issuecomment-2681544839

This allow end user to create its own listener as long as it returns a `xitca_io::net::stream` 

I did not make stream generic (could be in the future) neither.

Compared to the comment i choose to not make the Listen type generic, it could be in the future with another PR

In draft for the moment as i want to test this change on my project to be sure that i achieve what i want (getting back listener after shutdown)