### PR TITLE
feat(io): expose quic listener to be build from third party lib

### DIFF
--- a/io/src/net/quic.rs
+++ b/io/src/net/quic.rs
@@ -17,6 +17,10 @@ pub struct QuicListener {
 }
 
 impl QuicListener {
+    pub fn new(endpoint: Endpoint) -> Self {
+        Self { endpoint }
+    }
+
     pub fn endpoint(&self) -> &Endpoint {
         &self.endpoint
     }


### PR DESCRIPTION
This allow to create QuicListener when you don't want to use the builder.

Mainly this is because i have an already udp socket already binded and want to use it for the quic protocol instead of binding a new one (when transfering ownership of socket between process), see https://github.com/HFQR/xitca-web/issues/1190 for more context