### PR TITLE
Change tuple value of ParamsRef to public

### DIFF
--- a/web/src/handler/types/params.rs
+++ b/web/src/handler/types/params.rs
@@ -59,7 +59,7 @@ impl<'a, 'r, C, B, T> FromRequest<'a, WebContext<'r, C, B>> for LazyParams<'a, T
 }
 
 #[derive(Debug)]
-pub struct ParamsRef<'a>(&'a router::Params);
+pub struct ParamsRef<'a>(pub &'a router::Params);
 
 impl Deref for ParamsRef<'_> {
     type Target = router::Params;


### PR DESCRIPTION
Just like the title, I think that the usage is like `PathRef`, so I changed it, I don't know if it is a bug or not.