### PR TITLE
fix(http): when transforming a request to response keep the same http version

### DIFF
--- a/http/src/http.rs
+++ b/http/src/http.rs
@@ -98,6 +98,7 @@ where
             request::Parts {
                 mut headers,
                 extensions,
+                version,
                 ..
             },
             _,
@@ -107,6 +108,7 @@ where
         let mut res = Response::new(body.into());
         *res.headers_mut() = headers;
         *res.extensions_mut() = extensions;
+        *res.version_mut() = version;
 
         res
     }


### PR DESCRIPTION
By default response version will be "1.1" , this fix ensure that we have the same version as the request for a response by default, it's required when some middleware may need to do various check depending on the response version ref https://github.com/HFQR/xitca-web/pull/1240