### PR TITLE
feat(h2): send empty data frame instead of trailers header if empty

### DIFF
--- a/http/src/h2/proto/dispatcher.rs
+++ b/http/src/h2/proto/dispatcher.rs
@@ -211,6 +211,8 @@ enum ConnectionState {
     Close,
 }
 
+const EMPTY_DATA_FRAME : Bytes = Bytes::from_static(b"");
+
 // handle request/response and return if connection should go into graceful shutdown.
 async fn h2_handler<Fut, B, SE, BE>(
     fut: Fut,
@@ -297,8 +299,16 @@ where
             }
         }
     }
-
-    stream.send_trailers(trailers)?;
+    
+    if trailers.is_empty() {
+        // If trailers is empty, send an empty data frame to signal end of stream.
+        // It should be ok to send trailers even if empty but some client library does not like it.
+        // see https://gitlab.gnome.org/GNOME/libsoup/-/issues/457 
+        stream.send_data(EMPTY_DATA_FRAME, true)?;
+    } else {
+        // send trailers if there is any.
+        stream.send_trailers(trailers)?;
+    }
 
     Ok(state)
 }


### PR DESCRIPTION
While testing some of our servers with epiphany web browser (gnome) we see that it got stucked when we the response comes from xitca.

After some digging we found that this web browser does not like having trailer headers at the end of the h2 response.

But since most of the time, response, does not have trailer header i think sending an empty data frame with a close stream flag is better than sending a headers frame, and make it work for this browser.

See https://github.com/hyperium/h2/issues/845 and https://gitlab.gnome.org/GNOME/libsoup/-/issues/457