### PR TITLE
Fast shutdown

### DIFF
--- a/http/src/builder.rs
+++ b/http/src/builder.rs
@@ -210,6 +210,6 @@ where
     async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
         let service = res.map_err(|e| Box::new(e) as Error)?;
         let tls_acceptor = self.tls_factory.call(()).await.map_err(|e| Box::new(e) as Error)?;
-        Ok(HttpService::new(self.config, service, tls_acceptor))
+        Ok(HttpService::new(self.config.clone(), service, tls_acceptor))
     }
 }

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -19,7 +19,7 @@ pub const DEFAULT_WRITE_BUF_LIMIT: usize = 8192 + 4096 * 100;
 /// 64 chosen for no particular reason.
 pub const DEFAULT_HEADER_LIMIT: usize = 64;
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct HttpServiceConfig<
     const HEADER_LIMIT: usize = DEFAULT_HEADER_LIMIT,
     const READ_BUF_LIMIT: usize = DEFAULT_READ_BUF_LIMIT,

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -2,7 +2,7 @@
 
 use core::time::Duration;
 
-use crate::util::timer::Shutdown;
+use xitca_service::shutdown::{BoxShutdownListener, ShutdownListener};
 
 /// The default maximum read buffer size. If the head gets this big and
 /// a message is still not complete, a `TooLarge` error is triggered.
@@ -36,7 +36,7 @@ pub struct HttpServiceConfig<
     pub(crate) h2_initial_window_size: u32,
     pub(crate) h2_max_frame_size: u32,
     pub(crate) h2_max_header_list_size: u32,
-    pub(crate) shutdown: Option<Shutdown>,
+    pub(crate) shutdown: Option<BoxShutdownListener>,
 }
 
 impl Default for HttpServiceConfig {
@@ -190,8 +190,8 @@ impl<const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIM
     /// Define a shutdown signal for the service.
     /// When the signal is triggered, the service would stop accepting new connections and
     /// gracefully shutdown existing connections.
-    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
-        self.shutdown = Some(shutdown);
+    pub fn shutdown(mut self, shutdown: impl ShutdownListener + Sync + 'static) -> Self {
+        self.shutdown = Some(BoxShutdownListener::new(shutdown));
         self
     }
 

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -2,6 +2,8 @@
 
 use core::time::Duration;
 
+use crate::util::timer::Shutdown;
+
 /// The default maximum read buffer size. If the head gets this big and
 /// a message is still not complete, a `TooLarge` error is triggered.
 ///
@@ -34,6 +36,7 @@ pub struct HttpServiceConfig<
     pub(crate) h2_initial_window_size: u32,
     pub(crate) h2_max_frame_size: u32,
     pub(crate) h2_max_header_list_size: u32,
+    pub(crate) shutdown: Option<Shutdown>,
 }
 
 impl Default for HttpServiceConfig {
@@ -54,6 +57,7 @@ impl HttpServiceConfig {
             h2_initial_window_size: 65_535,
             h2_max_frame_size: 16_384,
             h2_max_header_list_size: 16 * 1024 * 1024,
+            shutdown: None,
         }
     }
 }
@@ -107,7 +111,7 @@ impl<const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIM
     ///
     /// When called in a const context (e.g. `const CFG: _ = HttpServiceConfig::new()...`)
     /// a violation is reported as a compile-time error instead of a runtime panic.
-    pub const fn max_read_buf_size<const READ_BUF_LIMIT_2: usize>(
+    pub fn max_read_buf_size<const READ_BUF_LIMIT_2: usize>(
         self,
     ) -> HttpServiceConfig<HEADER_LIMIT, READ_BUF_LIMIT_2, WRITE_BUF_LIMIT> {
         assert!(READ_BUF_LIMIT_2 >= 32, "READ_BUF_LIMIT must be no less than 32 bytes");
@@ -119,17 +123,17 @@ impl<const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIM
     ///
     /// See [DEFAULT_WRITE_BUF_LIMIT] for default value
     /// and behavior.
-    pub const fn max_write_buf_size<const WRITE_BUF_LIMIT_2: usize>(
+    pub fn max_write_buf_size<const WRITE_BUF_LIMIT_2: usize>(
         self,
     ) -> HttpServiceConfig<HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT_2> {
         self.mutate_const_generic::<HEADER_LIMIT, READ_BUF_LIMIT, WRITE_BUF_LIMIT_2>()
     }
 
-    /// Define max request header count for a connection.    
+    /// Define max request header count for a connection.
     ///
     /// See [DEFAULT_HEADER_LIMIT] for default value
     /// and behavior.
-    pub const fn max_request_headers<const HEADER_LIMIT_2: usize>(
+    pub fn max_request_headers<const HEADER_LIMIT_2: usize>(
         self,
     ) -> HttpServiceConfig<HEADER_LIMIT_2, READ_BUF_LIMIT, WRITE_BUF_LIMIT> {
         self.mutate_const_generic::<HEADER_LIMIT_2, READ_BUF_LIMIT, WRITE_BUF_LIMIT>()
@@ -183,9 +187,17 @@ impl<const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIM
         self
     }
 
+    /// Define a shutdown signal for the service.
+    /// When the signal is triggered, the service would stop accepting new connections and
+    /// gracefully shutdown existing connections.
+    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
+        self.shutdown = Some(shutdown);
+        self
+    }
+
     #[doc(hidden)]
     /// A shortcut for mutating const generic params.
-    pub const fn mutate_const_generic<
+    pub fn mutate_const_generic<
         const HEADER_LIMIT2: usize,
         const READ_BUF_LIMIT2: usize,
         const WRITE_BUF_LIMIT2: usize,
@@ -202,6 +214,7 @@ impl<const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, const WRITE_BUF_LIM
             h2_initial_window_size: self.h2_initial_window_size,
             h2_max_frame_size: self.h2_max_frame_size,
             h2_max_header_list_size: self.h2_max_header_list_size,
+            shutdown: self.shutdown,
         }
     }
 }

--- a/http/src/h1/builder.rs
+++ b/http/src/h1/builder.rs
@@ -72,6 +72,6 @@ where
     async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
         let service = res.map_err(|e| Box::new(e) as Error)?;
         let tls_acceptor = self.tls_factory.call(()).await.map_err(|e| Box::new(e) as Error)?;
-        Ok(H1Service::new(self.config, service, tls_acceptor))
+        Ok(H1Service::new(self.config.clone(), service, tls_acceptor))
     }
 }

--- a/http/src/h1/dispatcher.rs
+++ b/http/src/h1/dispatcher.rs
@@ -21,7 +21,7 @@ use crate::{
     date::DateTime,
     h1::error::Error,
     http::{StatusCode, response::Response},
-    util::timer::{KeepAlive, Timeout},
+    util::timer::{KeepAlive, KeepAliveOutput, Timeout},
 };
 
 use super::{
@@ -98,7 +98,8 @@ where
                         break Ok(());
                     }
                 }
-                Err(_) => break Err(dispatcher.timer.map_to_err()),
+                Err(KeepAliveOutput::Cancel) => break Ok(()),
+                Err(KeepAliveOutput::Expire) => break Err(dispatcher.timer.map_to_err()),
             }
         };
 

--- a/http/src/h1/service.rs
+++ b/http/src/h1/service.rs
@@ -45,7 +45,7 @@ where
             addr,
             crate::bytes::BytesMut::new(),
             timer,
-            self.config,
+            self.config.clone(),
             &self.service,
             self.date.get(),
         )

--- a/http/src/h2/builder.rs
+++ b/http/src/h2/builder.rs
@@ -71,6 +71,6 @@ where
     async fn call(&self, res: Result<S, E>) -> Result<Self::Response, Self::Error> {
         let service = res.map_err(|e| Box::new(e) as Error)?;
         let tls_acceptor = self.tls_factory.call(()).await.map_err(|e| Box::new(e) as Error)?;
-        Ok(H2Service::new(self.config, service, tls_acceptor))
+        Ok(H2Service::new(self.config.clone(), service, tls_acceptor))
     }
 }

--- a/http/src/service.rs
+++ b/http/src/service.rs
@@ -196,7 +196,7 @@ where
                 _addr,
                 _read_buf,
                 _timer.as_mut(),
-                self.config,
+                self.config.clone(),
                 &self.service,
                 self.date.get(),
             )

--- a/http/src/service.rs
+++ b/http/src/service.rs
@@ -154,7 +154,8 @@ impl<V, Io, St, S, A, const HEADER_LIMIT: usize, const READ_BUF_LIMIT: usize, co
     pub(crate) fn keep_alive(&self) -> KeepAlive {
         let accept_dur = self.config.tls_accept_timeout;
         let deadline = self.date.get().now() + accept_dur;
-        KeepAlive::new(deadline)
+
+        KeepAlive::new(deadline, self.config.shutdown.clone())
     }
 }
 

--- a/http/src/util/mod.rs
+++ b/http/src/util/mod.rs
@@ -5,7 +5,9 @@ pub mod service;
 
 pub(crate) mod futures;
 #[cfg(feature = "runtime")]
+pub(crate) mod shutdown;
+#[cfg(feature = "runtime")]
 pub(crate) mod timer;
 
 #[cfg(feature = "runtime")]
-pub use timer::{Shutdown, ShutdownHandle};
+pub use shutdown::{ShutdownHandle, ShutdownToken};

--- a/http/src/util/mod.rs
+++ b/http/src/util/mod.rs
@@ -6,3 +6,6 @@ pub mod service;
 pub(crate) mod futures;
 #[cfg(feature = "runtime")]
 pub(crate) mod timer;
+
+#[cfg(feature = "runtime")]
+pub use timer::{Shutdown, ShutdownHandle};

--- a/http/src/util/shutdown.rs
+++ b/http/src/util/shutdown.rs
@@ -1,0 +1,47 @@
+//! a [`tokio::sync::watch`] backed implementation of the runtime agnostic shutdown
+//! traits from [`xitca_service::shutdown`].
+
+use tokio::sync::watch;
+use xitca_service::shutdown::{ShutdownEmitter, ShutdownListener};
+
+/// A cloneable shutdown listener. Pass one (or a clone) to
+/// [`HttpServiceConfig::shutdown`](crate::config::HttpServiceConfig::shutdown) for every
+/// service that should observe the same shutdown signal.
+#[derive(Clone)]
+pub struct ShutdownToken {
+    receiver: watch::Receiver<bool>,
+}
+
+impl ShutdownToken {
+    /// Create a new `ShutdownToken` together with the [`ShutdownHandle`] that can trigger
+    /// it. Clone the returned token to hand it to multiple services.
+    pub fn new() -> (Self, ShutdownHandle) {
+        let (sender, receiver) = watch::channel(false);
+        (Self { receiver }, ShutdownHandle { sender })
+    }
+}
+
+impl ShutdownListener for ShutdownToken {
+    async fn wait(self) {
+        let mut receiver = self.receiver;
+        // resolve as soon as the sender flips the value or is dropped. the concrete value
+        // is irrelevant: any change means shutdown was signalled.
+        let _ = receiver.changed().await;
+    }
+}
+
+/// Triggers shutdown across every [`ShutdownToken`] cloned from the same source.
+///
+/// Dropping this handle does **not** trigger shutdown; call
+/// [`shutdown`](ShutdownEmitter::shutdown) explicitly.
+pub struct ShutdownHandle {
+    sender: watch::Sender<bool>,
+}
+
+impl ShutdownEmitter for ShutdownHandle {
+    fn shutdown(&self) {
+        // Ignore the error: it only occurs when all receivers have been dropped,
+        // which means there is nothing left to notify.
+        let _ = self.sender.send(true);
+    }
+}

--- a/http/src/util/timer.rs
+++ b/http/src/util/timer.rs
@@ -28,7 +28,7 @@ pin_project! {
 }
 
 impl<F: Future> Future for TimeoutFuture<'_, F> {
-    type Output = Result<F::Output, ()>;
+    type Output = Result<F::Output, KeepAliveOutput>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
@@ -79,17 +79,25 @@ impl KeepAlive {
 }
 
 impl Future for KeepAlive {
-    type Output = ();
+    type Output = KeepAliveOutput;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.as_mut().project();
         ready!(this.timer.poll(cx));
 
         if self.is_expired() {
-            Poll::Ready(())
+            Poll::Ready(KeepAliveOutput::Expire)
         } else {
             self.as_mut().reset();
             self.poll(cx)
         }
     }
+}
+
+/// return type of timer when it's finished
+pub enum KeepAliveOutput {
+    /// Timer is canceled by foreign input
+    Cancel,
+    /// Timer is explired
+    Expire,
 }

--- a/http/src/util/timer.rs
+++ b/http/src/util/timer.rs
@@ -4,10 +4,8 @@ use core::{
 };
 
 use pin_project_lite::pin_project;
-use tokio::{
-    sync::watch,
-    time::{Instant, Sleep, sleep_until},
-};
+use tokio::time::{Instant, Sleep, sleep_until};
+use xitca_service::shutdown::ShutdownListener;
 
 pub(crate) trait Timeout: Sized {
     fn timeout(self, timer: Pin<&mut KeepAlive>) -> TimeoutFuture<'_, Self>;
@@ -58,17 +56,12 @@ pin_project! {
 
 impl KeepAlive {
     #[inline]
-    pub fn new(deadline: Instant, shutdown: Option<Shutdown>) -> Self {
+    pub fn new(deadline: Instant, shutdown: Option<impl ShutdownListener + 'static>) -> Self {
         Self {
             timer: sleep_until(deadline),
             deadline,
-            shutdown: shutdown.map(|s| {
-                let mut receiver = s.receiver;
-
-                Box::pin(async move {
-                    let _ = receiver.changed().await;
-                }) as Pin<Box<dyn Future<Output = ()> + Send>>
-            }),
+            shutdown: shutdown
+                .map(|s| Box::pin(s.wait()) as Pin<Box<dyn Future<Output = ()> + Send>>),
         }
     }
 
@@ -118,38 +111,4 @@ pub enum KeepAliveOutput {
     Cancel,
     /// Timer is expired
     Expire,
-}
-
-/// A cloneable shutdown receiver. Pass one (or a clone) to [`KeepAlive::with_shutdown`]
-/// for every connection that should observe the same shutdown signal.
-#[derive(Clone)]
-pub struct Shutdown {
-    receiver: watch::Receiver<bool>,
-}
-
-impl Shutdown {
-    /// Creates a new `Shutdown` token together with the [`ShutdownHandle`] that
-    /// can trigger it. Clone the returned `Shutdown` to hand it to multiple
-    /// [`KeepAlive`] instances.
-    pub fn new() -> (Self, ShutdownHandle) {
-        let (sender, receiver) = watch::channel(false);
-        (Self { receiver }, ShutdownHandle { sender })
-    }
-}
-
-/// Triggers shutdown across every [`KeepAlive`] instance that was created with
-/// the associated [`Shutdown`] token.
-///
-/// Dropping this handle does **not** trigger shutdown; call [`shutdown`](ShutdownHandle::shutdown)
-/// explicitly.
-pub struct ShutdownHandle {
-    sender: watch::Sender<bool>,
-}
-
-impl xitca_service::shutdown::Shutdown for ShutdownHandle {
-    fn shutdown(&self) {
-        // Ignore the error: it only occurs when all receivers have been dropped,
-        // which means there is nothing left to notify.
-        let _ = self.sender.send(true);
-    }
 }

--- a/http/src/util/timer.rs
+++ b/http/src/util/timer.rs
@@ -4,7 +4,10 @@ use core::{
 };
 
 use pin_project_lite::pin_project;
-use tokio::time::{Instant, Sleep, sleep_until};
+use tokio::{
+    sync::watch,
+    time::{Instant, Sleep, sleep_until},
+};
 
 pub(crate) trait Timeout: Sized {
     fn timeout(self, timer: Pin<&mut KeepAlive>) -> TimeoutFuture<'_, Self>;
@@ -49,15 +52,23 @@ pin_project! {
         #[pin]
         timer: Sleep,
         deadline: Instant,
+        shutdown: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
     }
 }
 
 impl KeepAlive {
     #[inline]
-    pub fn new(deadline: Instant) -> Self {
+    pub fn new(deadline: Instant, shutdown: Option<Shutdown>) -> Self {
         Self {
             timer: sleep_until(deadline),
             deadline,
+            shutdown: shutdown.map(|s| {
+                let mut receiver = s.receiver;
+
+                Box::pin(async move {
+                    let _ = receiver.changed().await;
+                }) as Pin<Box<dyn Future<Output = ()> + Send>>
+            }),
         }
     }
 
@@ -83,6 +94,13 @@ impl Future for KeepAlive {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.as_mut().project();
+
+        if let Some(shutdown_fut) = this.shutdown.as_mut() {
+            if shutdown_fut.as_mut().poll(cx).is_ready() {
+                return Poll::Ready(KeepAliveOutput::Cancel);
+            }
+        }
+
         ready!(this.timer.poll(cx));
 
         if self.is_expired() {
@@ -96,8 +114,42 @@ impl Future for KeepAlive {
 
 /// return type of timer when it's finished
 pub enum KeepAliveOutput {
-    /// Timer is canceled by foreign input
+    /// Timer is canceled by foreign input (e.g. a shutdown signal)
     Cancel,
-    /// Timer is explired
+    /// Timer is expired
     Expire,
+}
+
+/// A cloneable shutdown receiver. Pass one (or a clone) to [`KeepAlive::with_shutdown`]
+/// for every connection that should observe the same shutdown signal.
+#[derive(Clone)]
+pub struct Shutdown {
+    receiver: watch::Receiver<bool>,
+}
+
+impl Shutdown {
+    /// Creates a new `Shutdown` token together with the [`ShutdownHandle`] that
+    /// can trigger it. Clone the returned `Shutdown` to hand it to multiple
+    /// [`KeepAlive`] instances.
+    pub fn new() -> (Self, ShutdownHandle) {
+        let (sender, receiver) = watch::channel(false);
+        (Self { receiver }, ShutdownHandle { sender })
+    }
+}
+
+/// Triggers shutdown across every [`KeepAlive`] instance that was created with
+/// the associated [`Shutdown`] token.
+///
+/// Dropping this handle does **not** trigger shutdown; call [`shutdown`](ShutdownHandle::shutdown)
+/// explicitly.
+pub struct ShutdownHandle {
+    sender: watch::Sender<bool>,
+}
+
+impl xitca_service::shutdown::Shutdown for ShutdownHandle {
+    fn shutdown(&self) {
+        // Ignore the error: it only occurs when all receivers have been dropped,
+        // which means there is nothing left to notify.
+        let _ = self.sender.send(true);
+    }
 }

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -6,7 +6,7 @@ use std::net;
 use std::sync::Arc;
 
 use xitca_io::net::Stream;
-use xitca_service::shutdown::Shutdown;
+use xitca_service::shutdown::ShutdownEmitter;
 
 use crate::{
     net::{IntoListener, ListenerDyn},
@@ -24,7 +24,7 @@ pub struct Builder {
     pub(crate) enable_signal: bool,
     pub(crate) shutdown_timeout: Duration,
     pub(crate) on_worker_start: Box<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>,
-    pub(crate) shutdown: Option<Box<dyn Shutdown + Send>>,
+    pub(crate) shutdown: Option<Box<dyn ShutdownEmitter + Send>>,
     backlog: u32,
 }
 
@@ -139,7 +139,7 @@ impl Builder {
     }
 
     /// Set shutdown handler for server.
-    pub fn shutdown(mut self, shutdown: impl Shutdown + 'static + Send) -> Self {
+    pub fn shutdown(mut self, shutdown: impl ShutdownEmitter + 'static + Send) -> Self {
         self.shutdown = Some(Box::new(shutdown));
         self
     }

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -6,6 +6,7 @@ use std::net;
 use std::sync::Arc;
 
 use xitca_io::net::Stream;
+use xitca_service::shutdown::Shutdown;
 
 use crate::{
     net::{IntoListener, ListenerDyn},
@@ -23,6 +24,7 @@ pub struct Builder {
     pub(crate) enable_signal: bool,
     pub(crate) shutdown_timeout: Duration,
     pub(crate) on_worker_start: Box<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>,
+    pub(crate) shutdown: Option<Box<dyn Shutdown + Send>>,
     backlog: u32,
 }
 
@@ -44,6 +46,7 @@ impl Builder {
             enable_signal: true,
             shutdown_timeout: Duration::from_secs(30),
             on_worker_start: Box::new(|| Box::pin(async {})),
+            shutdown: None,
             backlog: 2048,
         }
     }
@@ -132,6 +135,12 @@ impl Builder {
             })
         });
 
+        self
+    }
+
+    /// Set shutdown handler for server.
+    pub fn shutdown(mut self, shutdown: impl Shutdown + 'static + Send) -> Self {
+        self.shutdown = Some(Box::new(shutdown));
         self
     }
 

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -19,7 +19,7 @@ use tokio::{
     runtime::Runtime,
     sync::mpsc::{UnboundedReceiver, UnboundedSender},
 };
-use xitca_service::shutdown::Shutdown;
+use xitca_service::shutdown::ShutdownEmitter;
 
 use crate::{builder::Builder, worker};
 
@@ -28,7 +28,7 @@ pub struct Server {
     tx_cmd: UnboundedSender<Command>,
     rx_cmd: UnboundedReceiver<Command>,
     rt: Option<Runtime>,
-    shutdown: Option<Box<dyn Shutdown + Send>>,
+    shutdown: Option<Box<dyn ShutdownEmitter + Send>>,
     worker_join_handles: Vec<thread::JoinHandle<io::Result<()>>>,
 }
 

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -19,6 +19,7 @@ use tokio::{
     runtime::Runtime,
     sync::mpsc::{UnboundedReceiver, UnboundedSender},
 };
+use xitca_service::shutdown::Shutdown;
 
 use crate::{builder::Builder, worker};
 
@@ -27,6 +28,7 @@ pub struct Server {
     tx_cmd: UnboundedSender<Command>,
     rx_cmd: UnboundedReceiver<Command>,
     rt: Option<Runtime>,
+    shutdown: Option<Box<dyn Shutdown + Send>>,
     worker_join_handles: Vec<thread::JoinHandle<io::Result<()>>>,
 }
 
@@ -91,6 +93,7 @@ impl Server {
             factories,
             shutdown_timeout,
             on_worker_start,
+            shutdown,
             ..
         } = builder;
 
@@ -178,10 +181,15 @@ impl Server {
             rx_cmd,
             rt: Some(rt),
             worker_join_handles: vec![worker_handles],
+            shutdown,
         })
     }
 
     pub(crate) fn stop(&mut self, graceful: bool) {
+        if let Some(shutdown) = self.shutdown.take() {
+            shutdown.shutdown();
+        }
+
         if let Some(rt) = self.rt.take() {
             self.is_graceful_shutdown.store(graceful, Ordering::SeqCst);
             rt.shutdown_background();

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -35,6 +35,7 @@ mod service;
 pub mod middleware;
 pub mod pipeline;
 pub mod ready;
+pub mod shutdown;
 
 pub use self::{
     middleware::{EnclosedBuilder, EnclosedFnBuilder, MapBuilder, MapErrorBuilder},

--- a/service/src/shutdown.rs
+++ b/service/src/shutdown.rs
@@ -1,3 +1,79 @@
-pub trait Shutdown {
+//! traits decoupling application shutdown signalling from any async runtime.
+//!
+//! a [`ShutdownEmitter`] triggers shutdown and every [`ShutdownListener`] handed out
+//! beforehand resolves its future in response. neither trait is bound to a specific
+//! runtime: an implementor only has to produce a [`Future`] that resolves once shutdown
+//! is signalled.
+
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, sync::Arc};
+use core::future::Future;
+#[cfg(feature = "alloc")]
+use core::pin::Pin;
+
+/// emitter side of a shutdown signal.
+///
+/// calling [`shutdown`](ShutdownEmitter::shutdown) resolves the future of every
+/// [`ShutdownListener`] derived from the same source.
+pub trait ShutdownEmitter {
+    /// signal shutdown. every associated [`ShutdownListener`] is resolved as a result.
     fn shutdown(&self);
+}
+
+/// listener side of a shutdown signal.
+///
+/// a listener is [`Clone`] and [`Send`] so the same shutdown source can be observed by
+/// services running on different threads. [`wait`](ShutdownListener::wait) consumes the
+/// listener and returns a future resolving once the associated [`ShutdownEmitter`]
+/// signals shutdown. the resolved value carries no information: observing the resolution
+/// is the signal.
+pub trait ShutdownListener: Clone + Send {
+    /// consume the listener and wait for shutdown to be signalled.
+    fn wait(self) -> impl Future<Output = ()> + Send;
+}
+
+/// a type erased, cheaply cloneable [`ShutdownListener`].
+///
+/// [`ShutdownListener`] is not object safe (it is generic over the future it returns and
+/// requires [`Clone`]), so it can not be stored as a `dyn` trait object directly. wrap any
+/// listener in a `BoxShutdownListener` to store it in a type that must stay free of generic
+/// parameters (e.g. a configuration struct). the concrete listener is erased behind a
+/// reference counted trait object so cloning only bumps the reference count.
+#[cfg(feature = "alloc")]
+#[derive(Clone)]
+pub struct BoxShutdownListener {
+    inner: Arc<dyn DynShutdownListener>,
+}
+
+#[cfg(feature = "alloc")]
+impl BoxShutdownListener {
+    /// erase `listener` behind a [`BoxShutdownListener`].
+    pub fn new(listener: impl ShutdownListener + Sync + 'static) -> Self {
+        Self { inner: Arc::new(listener) }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl ShutdownListener for BoxShutdownListener {
+    fn wait(self) -> impl Future<Output = ()> + Send {
+        self.inner.wait()
+    }
+}
+
+/// object safe counterpart of [`ShutdownListener`] used to erase the listener type behind
+/// [`BoxShutdownListener`]. `wait` takes `&self` and clones internally so the trait object
+/// stays shareable, and the future is boxed to escape the associated type.
+#[cfg(feature = "alloc")]
+trait DynShutdownListener: Send + Sync {
+    fn wait(&self) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+}
+
+#[cfg(feature = "alloc")]
+impl<L> DynShutdownListener for L
+where
+    L: ShutdownListener + Sync + 'static,
+{
+    fn wait(&self) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        Box::pin(self.clone().wait())
+    }
 }

--- a/service/src/shutdown.rs
+++ b/service/src/shutdown.rs
@@ -1,0 +1,3 @@
+pub trait Shutdown {
+    fn shutdown(&self);
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -2,8 +2,7 @@ use std::{
     error, fmt, fs,
     future::Future,
     io,
-    net::SocketAddr,
-    net::TcpListener,
+    net::{SocketAddr, TcpListener},
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -15,6 +14,7 @@ use xitca_http::{
     config::HttpServiceConfig,
     h1, h2, h3,
     http::{Request, RequestExt, Response},
+    util::{Shutdown, ShutdownHandle},
 };
 use xitca_io::{bytes::Bytes, net::Stream as NetStream};
 use xitca_server::{Builder, ServerFuture, ServerHandle};
@@ -26,7 +26,7 @@ type HResponse<B> = Response<B>;
 
 /// A general test server for any given service type that accept the connection from
 /// xitca-server
-pub fn test_server<T, Req>(service: T) -> Result<TestServerHandle, Error>
+pub fn test_server<T, Req>(service: T, shutdown: Option<ShutdownHandle>) -> Result<TestServerHandle, Error>
 where
     T: Service + Send + Sync + 'static,
     T::Response: ReadyService + Service<Req>,
@@ -36,12 +36,17 @@ where
 
     let addr = lst.local_addr()?;
 
-    let handle = Builder::new()
+    let builder = Builder::new()
         .worker_threads(1)
         .server_threads(1)
         .disable_signal()
-        .listen::<_, _, _, Req>("test_server", lst, service)
-        .build();
+        .listen::<_, _, _, Req>("test_server", lst, service);
+
+    let handle = if let Some(shutdown) = shutdown {
+        builder.shutdown(shutdown).build()
+    } else {
+        builder.build()
+    };
 
     Ok(TestServerHandle { addr, handle })
 }
@@ -56,12 +61,14 @@ where
     B: Body<Data = Bytes> + 'static,
     B::Error: fmt::Debug + 'static,
 {
-    let builder = HttpServiceBuilder::h1();
+    let (shutdown, handle) = Shutdown::new();
+    let config = HttpServiceConfig::new().shutdown(shutdown);
+    let builder = HttpServiceBuilder::h1().config(config);
 
     #[cfg(feature = "io-uring")]
     let builder = builder.io_uring();
 
-    test_server(service.enclosed(builder))
+    test_server(service.enclosed(builder), Some(handle))
 }
 
 /// A specialized http/2 server on top of [test_server]
@@ -74,17 +81,19 @@ where
     B: Body<Data = Bytes> + 'static,
     B::Error: fmt::Debug + 'static,
 {
+    let (shutdown, handle) = Shutdown::new();
     let builder = HttpServiceBuilder::h2().config(
         HttpServiceConfig::new()
             .request_head_timeout(Duration::from_millis(500))
             .tls_accept_timeout(Duration::from_millis(500))
-            .keep_alive_timeout(Duration::from_millis(500)),
+            .keep_alive_timeout(Duration::from_millis(500))
+            .shutdown(shutdown),
     );
 
     #[cfg(feature = "io-uring")]
     let builder = builder.io_uring();
 
-    test_server(service.enclosed(builder))
+    test_server(service.enclosed(builder), Some(handle))
 }
 
 /// A specialized http/3 server

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -14,7 +14,7 @@ use xitca_http::{
     config::HttpServiceConfig,
     h1, h2, h3,
     http::{Request, RequestExt, Response},
-    util::{Shutdown, ShutdownHandle},
+    util::{ShutdownHandle, ShutdownToken},
 };
 use xitca_io::{bytes::Bytes, net::Stream as NetStream};
 use xitca_server::{Builder, ServerFuture, ServerHandle};
@@ -61,7 +61,7 @@ where
     B: Body<Data = Bytes> + 'static,
     B::Error: fmt::Debug + 'static,
 {
-    let (shutdown, handle) = Shutdown::new();
+    let (shutdown, handle) = ShutdownToken::new();
     let config = HttpServiceConfig::new().shutdown(shutdown);
     let builder = HttpServiceBuilder::h1().config(config);
 
@@ -81,7 +81,7 @@ where
     B: Body<Data = Bytes> + 'static,
     B::Error: fmt::Debug + 'static,
 {
-    let (shutdown, handle) = Shutdown::new();
+    let (shutdown, handle) = ShutdownToken::new();
     let builder = HttpServiceBuilder::h2().config(
         HttpServiceConfig::new()
             .request_head_timeout(Duration::from_millis(500))

--- a/test/tests/h1.rs
+++ b/test/tests/h1.rs
@@ -269,6 +269,35 @@ async fn h1_keepalive() -> Result<(), Error> {
     Ok(())
 }
 
+#[tokio::test]
+async fn h1_fast_shutdown() -> Result<(), Error> {
+    let mut handle = test_h1_server(fn_service(handle))?;
+
+    let server_url = format!("http://{}/", handle.ip_port_string());
+
+    let c = Client::new();
+
+    let mut res = c.get(&server_url).version(Version::HTTP_11).send().await?;
+    assert_eq!(res.status().as_u16(), 200);
+    assert!(!res.can_close_connection());
+    let body = res.string().await?;
+    assert_eq!("GET Response", body);
+
+    let start = std::time::Instant::now();
+
+    handle.try_handle()?.stop(true);
+    handle.await?;
+
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "server did not shutdown fast, elapsed: {:?}",
+        elapsed
+    );
+
+    Ok(())
+}
+
 async fn handle(req: Request<RequestExt<h1::RequestBody>>) -> Result<Response<ResponseBody>, Error> {
     match (req.method(), req.uri().path()) {
         (&Method::GET, "/") | (&Method::HEAD, "/") => Ok(Response::new(Bytes::from("GET Response").into())),

--- a/test/tests/h2.rs
+++ b/test/tests/h2.rs
@@ -405,6 +405,35 @@ async fn h2_forceful_goaway_on_rapid_reset_drains_delayed_stream() -> Result<(),
     Ok(())
 }
 
+#[tokio::test]
+async fn h2_fast_shutdown() -> Result<(), Error> {
+    let mut handle = test_h2_server(fn_service(handle))?;
+
+    let server_url = format!("https://{}/", handle.ip_port_string());
+
+    let c = Client::new();
+
+    let mut res = c.get(&server_url).version(Version::HTTP_2).send().await?;
+    assert_eq!(res.status().as_u16(), 200);
+    assert!(!res.can_close_connection());
+    let body = res.string().await?;
+    assert_eq!("GET Response", body);
+
+    let start = std::time::Instant::now();
+
+    handle.try_handle()?.stop(true);
+    handle.await?;
+
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "server did not shutdown fast, elapsed: {:?}",
+        elapsed
+    );
+
+    Ok(())
+}
+
 async fn handle(req: Request<RequestExt<h2::RequestBody>>) -> Result<Response<ResponseBody>, Error> {
     // Some yield for testing h2 dispatcher's concurrent future handling.
     tokio::task::yield_now().await;

--- a/web/src/server.rs
+++ b/web/src/server.rs
@@ -197,7 +197,7 @@ where
         ResB: Body<Data = Bytes> + 'static,
         ResB::Error: fmt::Debug + 'static,
     {
-        let http = HttpServiceBuilder::with_config(self.config);
+        let http = HttpServiceBuilder::with_config(self.config.clone());
         let service = self.service.clone();
         let name = "xitca-web";
 
@@ -226,7 +226,7 @@ where
         ResB::Error: fmt::Debug + 'static,
         L: IntoListener + 'static,
     {
-        let http = HttpServiceBuilder::with_config(self.config);
+        let http = HttpServiceBuilder::with_config(self.config.clone());
         let service = self.service.clone();
         let name = "xitca-web";
 
@@ -259,7 +259,7 @@ where
         ResB: Body<Data = Bytes> + 'static,
         ResB::Error: fmt::Debug + 'static,
     {
-        let config = self.config;
+        let config = self.config.clone();
 
         const H11: &[u8] = b"\x08http/1.1";
 
@@ -323,7 +323,7 @@ where
         ResB: Body<Data = Bytes> + 'static,
         ResB::Error: fmt::Debug + 'static,
     {
-        let service_config = self.config;
+        let service_config = self.config.clone();
 
         #[cfg(feature = "http2")]
         config.alpn_protocols.push("h2".into());
@@ -361,7 +361,7 @@ where
         ResB: Body<Data = Bytes> + 'static,
         ResB::Error: fmt::Debug + 'static,
     {
-        let http = HttpServiceBuilder::with_config(self.config);
+        let http = HttpServiceBuilder::with_config(self.config.clone());
         let name = "xitca-web";
         let service = self.service.clone();
         self.builder = if self.enable_io_uring {
@@ -396,7 +396,7 @@ where
         let service = self
             .service
             .clone()
-            .enclosed(HttpServiceBuilder::with_config(self.config));
+            .enclosed(HttpServiceBuilder::with_config(self.config.clone()));
 
         self.builder = self.builder.bind_h3("xitca-web", addr, config, service)?;
         Ok(self)


### PR DESCRIPTION
This PR replace https://github.com/HFQR/xitca-web/pull/1193
It uses the cancel on timer done in https://github.com/HFQR/xitca-web/pull/1366

It add the shutdown / handle mecanism.

Even if it uses tokio::sync::watch we could get rid of that easily as it mostly rely on having a future that would be ready at some point, and when it's ready it means it is cancelled. So in the end it would only need those 2 behavior : having a future that is ready when shutdown has been called and being clonable.

I can already try to make it runtime independant if you need.