### PR TITLE
fix(h2): be sure to send settings frame before treating any read frame

### DIFF
--- a/http/src/h2/dispatcher.rs
+++ b/http/src/h2/dispatcher.rs
@@ -464,6 +464,23 @@ where
 
     flow.borrow_mut().init(settings);
 
+    // Encode and flush our initial SETTINGS frame before the main loop so it
+    // is always on the wire before we process any client frames (RFC 7540 §3.5).
+    poll_fn(|cx| {
+        let _ = enc.poll_encode(&mut write_buf, cx);
+        Poll::Ready(())
+    })
+    .await;
+    while !write_buf.is_empty() {
+        let (res, buf) = io.write(write_buf).await;
+        write_buf = buf;
+        match res {
+            Ok(0) => return Err(io::ErrorKind::WriteZero.into()),
+            Ok(n) => write_buf.advance(n),
+            Err(e) => return Err(e),
+        }
+    }
+
     let res = {
         let mut read_task = pin!(read_io::<READ_BUF_LIMIT>(read_buf, &io));
 


### PR DESCRIPTION
In some cases some clients where reporting an error as the settings initial frame was not sent.

I was having those 2 errors in curl and h2spec : 

<img width="578" height="132" alt="image" src="https://github.com/user-attachments/assets/aa074ae0-4596-4de3-ba96-c4662ec54a4c" />
<img width="1044" height="44" alt="image" src="https://github.com/user-attachments/assets/ff456ab5-c61c-46d6-afee-e7c3e3ef7b87" />

I believe that even if it was sent by the server, it was **too late** for the client.
This ensure this frame is sent before treating any other frames and fix those errors.
