### PR TITLE
feat(h1): handle close delimited body in http1.1

### DIFF
--- a/client/src/h1/body.rs
+++ b/client/src/h1/body.rs
@@ -53,6 +53,14 @@ impl Body for ResponseBody {
                     match xitca_unsafe_collection::bytes::read_buf(this.conn.deref_mut(), &mut this.buf) {
                         Ok(n) => {
                             if n == 0 {
+                                // Handle when body is connection-close delimited (no Content-Length,
+                                // no Transfer-Encoding). In that case a clean read of 0 bytes means
+                                // the server closed the connection and the body is complete.
+                                if matches!(this.decoder, TransferCoding::CloseDelimited) {
+                                    this.decoder.set_eof();
+                                    return Poll::Ready(None);
+                                }
+
                                 return Poll::Ready(Some(Err(io::Error::from(io::ErrorKind::UnexpectedEof).into())));
                             }
                             break 'inner;

--- a/client/src/h1/proto/decode.rs
+++ b/client/src/h1/proto/decode.rs
@@ -50,6 +50,13 @@ impl<const HEADER_LIMIT: usize> Context<'_, '_, HEADER_LIMIT> {
                     .iter()
                     .try_for_each(|idx| self.try_write_header(&mut headers, &mut decoder, idx, &slice, version))?;
 
+                // RFC 7230 §3.3.3: if no Content-Length and no Transfer-Encoding are present
+                // but the server sent Connection: close, the body is delimited by connection
+                // closure rather than being empty.
+                if matches!(decoder, TransferCoding::Eof) && self.is_connection_closed() {
+                    decoder = TransferCoding::close_delimited();
+                }
+
                 let mut res = Response::new(());
 
                 let extensions = self.take_extensions();

--- a/http/src/h1/proto/trasnder_coding.rs
+++ b/http/src/h1/proto/trasnder_coding.rs
@@ -33,6 +33,9 @@ pub enum TransferCoding {
     EncodeChunked,
     /// Upgrade type coder that pass through body as is without transforming.
     Upgrade,
+    /// Decoder for HTTP/1.0-style responses where the body is delimited by
+    /// connection closure (no Content-Length, no Transfer-Encoding, Connection: close).
+    CloseDelimited,
 }
 
 /// State for accumulating chunked trailer headers during decode.
@@ -149,6 +152,11 @@ impl TransferCoding {
         Self::Upgrade
     }
 
+    #[inline]
+    pub const fn close_delimited() -> Self {
+        Self::CloseDelimited
+    }
+
     /// Check if Self is in EOF state. An EOF state means TransferCoding is ended gracefully
     /// and can not decode any value. See [TransferCoding::decode] for detail.
     #[inline]
@@ -163,6 +171,11 @@ impl TransferCoding {
     #[inline]
     pub fn is_upgrade(&self) -> bool {
         matches!(self, Self::Upgrade)
+    }
+
+    #[inline]
+    pub fn is_close_delimited(&self) -> bool {
+        matches!(self, Self::CloseDelimited)
     }
 }
 
@@ -408,7 +421,7 @@ impl TransferCoding {
         }
 
         match *self {
-            Self::Upgrade => buf.write_buf_bytes(bytes),
+            Self::Upgrade | Self::CloseDelimited => buf.write_buf_bytes(bytes),
             Self::EncodeChunked => buf.write_buf_bytes_chunked(bytes),
             Self::Length(ref mut rem) => {
                 let len = bytes.len() as u64;
@@ -433,7 +446,7 @@ impl TransferCoding {
         W: H1BufWrite,
     {
         match *self {
-            Self::Eof | Self::Upgrade | Self::Length(0) => {}
+            Self::Eof | Self::Upgrade | Self::CloseDelimited | Self::Length(0) => {}
             Self::EncodeChunked => match trailers {
                 Some(trailers) => buf.write_buf_trailers(trailers),
                 None => buf.write_buf_static(b"0\r\n\r\n"),
@@ -462,7 +475,7 @@ impl TransferCoding {
             Self::Corrupted => ChunkResult::Corrupted,
             ref _this if src.is_empty() => ChunkResult::InsufficientData,
             Self::Length(ref mut rem) => ChunkResult::Ok(bounded_split(rem, src)),
-            Self::Upgrade => ChunkResult::Ok(src.split().freeze()),
+            Self::Upgrade | Self::CloseDelimited => ChunkResult::Ok(src.split().freeze()),
             Self::DecodeChunked {
                 ref mut state,
                 ref mut size,


### PR DESCRIPTION
This allow to correctly handle response body when there is no content-length, no transfer-encoding and a connection: close header (In this case the body size is unknown, and all bytes remaining in connection until connection is close = body)

See https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3