### PR TITLE
[client] allow to get connection out of pool which may be need for long lived connection

### DIFF
--- a/client/src/body.rs
+++ b/client/src/body.rs
@@ -63,17 +63,29 @@ impl ResponseBody {
     pub(crate) fn destroy_on_drop(&mut self) {
         #[cfg(feature = "http1")]
         if let Self::H1(ref mut body) = *self {
-            body.conn_mut().mark_destroy()
+            body.mark_destroy();
         }
     }
 
     pub(crate) fn can_destroy_on_drop(&mut self) -> bool {
         #[cfg(feature = "http1")]
         if let Self::H1(ref mut body) = *self {
-            return body.conn_mut().is_marked_destroy();
+            return body.is_marked_destroy();
         }
 
         false
+    }
+
+    pub fn detach_from_pool(&mut self) {
+        match self {
+            #[cfg(feature = "http1")]
+            Self::H1(body) => body.detach_from_pool(),
+            #[cfg(feature = "http2")]
+            Self::H1(body) => body.detach_from_pool(),
+            #[cfg(feature = "http3")]
+            Self::H1(body) => body.detach_from_pool(),
+            _ => (),
+        }
     }
 }
 

--- a/client/src/builder.rs
+++ b/client/src/builder.rs
@@ -174,7 +174,7 @@ impl ClientBuilder {
     ///
     /// // a lease of customized connection pool
     /// struct MyPoolLease {
-    ///     conn: ConnectionExclusive,
+    ///     conn: Option<ConnectionExclusive>,
     /// }
     ///
     /// // trait impls required for lease type
@@ -182,13 +182,13 @@ impl ClientBuilder {
     ///     type Target = ConnectionExclusive;
     ///
     ///     fn deref(&self) -> &Self::Target {
-    ///         &self.conn
+    ///         self.conn.as_ref().expect("conn must not be none")
     ///     }
     /// }
     ///
     /// impl DerefMut for MyPoolLease {
     ///     fn deref_mut(&mut self) -> &mut Self::Target {
-    ///         &mut self.conn
+    ///         self.conn.as_mut().expect("conn must not be none")
     ///     }
     /// }
     ///
@@ -197,6 +197,10 @@ impl ClientBuilder {
     ///
     ///     fn is_marked_destroy(&self) -> bool {
     ///         true
+    ///     }
+    ///
+    ///     fn detach(&mut self) -> ConnectionExclusive {
+    ///         self.conn.take().expect("Conn always contains a connection")
     ///     }
     /// }
     ///
@@ -210,7 +214,7 @@ impl ClientBuilder {
     ///         match req.spawn().await? {
     ///             SpawnOutCome::Exclusive { conn, version } => {
     ///                 // construct the customized lease type and return as result.
-    ///                 let lease = Lease::exclusive(MyPoolLease { conn }, version);
+    ///                 let lease = Lease::exclusive(MyPoolLease { conn: Some(conn) }, version);
     ///                 Ok(lease)
     ///             }
     ///             SpawnOutCome::Shared { .. } => todo!("shared connection for http2/http3"),

--- a/client/src/h1/body.rs
+++ b/client/src/h1/body.rs
@@ -1,5 +1,6 @@
 use std::{
     io,
+    ops::{Deref, DerefMut},
     pin::Pin,
     task::{Context, Poll, ready},
 };
@@ -13,10 +14,57 @@ use xitca_io::io::Interest;
 
 use crate::{
     body::{Body, Frame, SizeHint},
+    connection::ConnectionExclusive,
     pool::service::ExclusiveLease,
 };
 
-pub type Connection = ExclusiveLease;
+/// The connection backing an H1 response body.
+///
+/// `Pooled` holds the full pool lease (including the capacity semaphore permit).
+/// `Detached` holds only the raw TCP/TLS connection; the pool slot was already
+/// released. Use [`ResponseBody::detach_from_pool`] to transition from the
+/// former to the latter for long-lived responses such as Server-Sent Events.
+pub(crate) enum Connection {
+    Pooled(ExclusiveLease),
+    Detached(ConnectionExclusive),
+}
+
+impl Deref for Connection {
+    type Target = ConnectionExclusive;
+
+    fn deref(&self) -> &ConnectionExclusive {
+        match self {
+            Connection::Pooled(lease) => lease.deref(),
+            Connection::Detached(conn) => conn,
+        }
+    }
+}
+
+impl DerefMut for Connection {
+    fn deref_mut(&mut self) -> &mut ConnectionExclusive {
+        match self {
+            Connection::Pooled(lease) => lease.deref_mut(),
+            Connection::Detached(conn) => conn,
+        }
+    }
+}
+
+impl Connection {
+    fn mark_destroy(&mut self) {
+        if let Connection::Pooled(lease) = self {
+            lease.mark_destroy();
+        }
+    }
+
+    pub fn detach(&mut self) {
+        let conn = match self {
+            Connection::Pooled(lease) => lease.detach(),
+            Connection::Detached(_) => return,
+        };
+
+        *self = Connection::Detached(conn)
+    }
+}
 
 pub struct ResponseBody {
     conn: Connection,
@@ -25,16 +73,40 @@ pub struct ResponseBody {
 }
 
 impl ResponseBody {
-    pub(crate) fn new(conn: Connection, buf: BytesMut, decoder: TransferCoding) -> Self {
-        Self { conn, buf, decoder }
+    pub(crate) fn new(conn: ExclusiveLease, buf: BytesMut, decoder: TransferCoding) -> Self {
+        Self {
+            conn: Connection::Pooled(conn),
+            buf,
+            decoder,
+        }
     }
 
-    pub(crate) fn conn(&self) -> &Connection {
+    fn io_mut(&mut self) -> &mut ConnectionExclusive {
+        &mut self.conn
+    }
+
+    pub(crate) fn conn(&self) -> &ConnectionExclusive {
         &self.conn
     }
 
-    pub(crate) fn conn_mut(&mut self) -> &mut Connection {
-        &mut self.conn
+    pub(crate) fn conn_mut(&mut self) -> &mut ConnectionExclusive {
+        self.io_mut()
+    }
+
+    pub(crate) fn mark_destroy(&mut self) {
+        self.conn.mark_destroy();
+    }
+
+    pub(crate) fn is_marked_destroy(&self) -> bool {
+        match &self.conn {
+            Connection::Pooled(lease) => lease.is_marked_destroy(),
+            // Detached connections are never returned to the pool.
+            Connection::Detached(_) => true,
+        }
+    }
+
+    pub(crate) fn detach_from_pool(&mut self) {
+        self.conn.detach();
     }
 }
 

--- a/client/src/http_tunnel.rs
+++ b/client/src/http_tunnel.rs
@@ -41,7 +41,9 @@ impl HttpTunnelRequest<'_> {
             }));
         }
 
-        let body = res.res.into_body();
+        let mut body = res.res.into_body();
+        body.detach_from_pool();
+
         Ok(Tunnel::new(HttpTunnel {
             body,
             io: Default::default(),
@@ -142,7 +144,7 @@ where
         match self.get_mut().body {
             #[cfg(feature = "http1")]
             ResponseBody::H1(ref mut body) => {
-                xitca_io::io::AsyncIo::poll_shutdown(Pin::new(body.conn_mut().deref_mut()), cx).map_err(Into::into)
+                xitca_io::io::AsyncIo::poll_shutdown(Pin::new(body.conn_mut()), cx).map_err(Into::into)
             }
             #[cfg(feature = "http2")]
             ResponseBody::H2(ref mut body) => {
@@ -187,7 +189,7 @@ impl AsyncIo for HttpTunnel {
     fn is_vectored_write(&self) -> bool {
         match self.body {
             #[cfg(feature = "http1")]
-            ResponseBody::H1(ref body) => body.conn().is_vectored_write(),
+            ResponseBody::H1(ref body) => body.conn().is_vectored_write(), // conn() → &ConnectionExclusive
             _ => false,
         }
     }
@@ -196,7 +198,7 @@ impl AsyncIo for HttpTunnel {
         let this = self.get_mut();
         match this.body {
             #[cfg(feature = "http1")]
-            ResponseBody::H1(ref mut body) => AsyncIo::poll_shutdown(Pin::new(body.conn_mut().deref_mut()), _cx),
+            ResponseBody::H1(ref mut body) => AsyncIo::poll_shutdown(Pin::new(body.conn_mut()), _cx),
             #[cfg(feature = "http2")]
             ResponseBody::H2(ref mut body) => this.io.poll_shutdown(body, _cx),
             _ => Poll::Ready(Ok(())),

--- a/client/src/pool/exclusive.rs
+++ b/client/src/pool/exclusive.rs
@@ -215,6 +215,14 @@ where
     pub(crate) fn is_destroy_on_drop(&self) -> bool {
         self.destroy_on_drop
     }
+
+    /// Take the raw connection out of this wrapper, leaving `conn` as `None`.
+    /// When `Conn` subsequently drops, its `Drop` impl sees `None` and skips
+    /// re-queuing. The `OwnedSemaphorePermit` is still dropped, releasing the
+    /// pool capacity slot.
+    pub(crate) fn take_raw_conn(&mut self) -> Option<C> {
+        self.conn.take().map(PooledConn::into_inner)
+    }
 }
 
 impl<K, C> Drop for Conn<K, C>
@@ -264,6 +272,12 @@ impl<C> Deref for PooledConn<C> {
 impl<C> DerefMut for PooledConn<C> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.conn
+    }
+}
+
+impl<C> PooledConn<C> {
+    pub(crate) fn into_inner(self) -> C {
+        self.conn
     }
 }
 

--- a/client/src/pool/service.rs
+++ b/client/src/pool/service.rs
@@ -145,6 +145,12 @@ pub trait Leaser<Conn>: Send + Sync + DerefMut<Target = Conn> {
 
     /// returns true when the connection is marked as destroy-on-drop.
     fn is_marked_destroy(&self) -> bool;
+
+    /// Extract the raw connection, releasing the pool capacity slot immediately.
+    /// The returned connection is no longer tracked by the pool.
+    /// Use this for long-lived responses (e.g. Server-Sent Events) that must
+    /// not hold a pool permit for their entire lifetime.
+    fn detach(&mut self) -> Conn;
 }
 
 /// run dns resolve + transport connect + tls handshake + (when requested)
@@ -282,6 +288,10 @@ impl Leaser<ConnectionExclusive> for exclusive::Conn<ConnectionKey, ConnectionEx
     fn is_marked_destroy(&self) -> bool {
         self.is_destroy_on_drop()
     }
+
+    fn detach(&mut self) -> ConnectionExclusive {
+        self.take_raw_conn().expect("Conn always contains a connection")
+    }
 }
 
 impl Leaser<ConnectionShared> for shared::Conn<ConnectionKey, ConnectionShared> {
@@ -291,6 +301,10 @@ impl Leaser<ConnectionShared> for shared::Conn<ConnectionKey, ConnectionShared> 
 
     fn is_marked_destroy(&self) -> bool {
         self.is_destroy_on_drop()
+    }
+
+    fn detach(&mut self) -> ConnectionShared {
+        self.conn.clone()
     }
 }
 

--- a/client/src/service/http.rs
+++ b/client/src/service/http.rs
@@ -2,6 +2,7 @@ use crate::{
     Service, ServiceRequest,
     connect::Connect,
     error::Error,
+    http::header,
     pool::service::{Lease, PoolRequest},
     response::Response,
     service::ServiceDyn,
@@ -103,10 +104,14 @@ pub(crate) fn base_service() -> HttpService {
 
                         match res {
                             Ok(Ok((res, buf, decoder, is_close))) => {
+                                let is_sse = is_event_source(&res);
                                 if is_close {
                                     _conn.mark_destroy();
                                 }
-                                let body = crate::h1::body::ResponseBody::new(_conn, buf, decoder);
+                                let mut body = crate::h1::body::ResponseBody::new(_conn, buf, decoder);
+                                if is_sse {
+                                    body.detach_from_pool();
+                                }
                                 let res = res.map(|_| crate::body::ResponseBody::H1(body));
                                 let timeout = client.timeout_config.response_timeout;
                                 Ok(Response::new(res, timer, timeout))
@@ -133,4 +138,11 @@ pub(crate) fn base_service() -> HttpService {
     }
 
     Box::new(HttpService)
+}
+
+fn is_event_source(res: &crate::http::Response<()>) -> bool {
+    res.headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.starts_with("text/event-stream"))
 }

--- a/client/src/ws.rs
+++ b/client/src/ws.rs
@@ -65,7 +65,9 @@ impl WsRequest<'_> {
             }));
         }
 
-        let body = res.res.into_body();
+        let mut body = res.res.into_body();
+        body.detach_from_pool();
+
         Ok(WebSocket::new(WebSocketTunnel {
             codec: Codec::new().client_mode(),
             send_buf: BytesMut::new(),
@@ -156,7 +158,7 @@ impl Sink<Message> for WebSocketTunnel {
         match self.get_mut().recv_stream.inner_mut() {
             #[cfg(feature = "http1")]
             ResponseBody::H1(body) => {
-                xitca_io::io::AsyncIo::poll_shutdown(Pin::new(body.conn_mut().deref_mut()), cx).map_err(Into::into)
+                xitca_io::io::AsyncIo::poll_shutdown(Pin::new(body.conn_mut()), cx).map_err(Into::into)
             }
             #[cfg(feature = "http2")]
             ResponseBody::H2(body) => {


### PR DESCRIPTION
Allow body / connection to be detached from pool, use it for : 

 * Websocket request
 * Upgrade request
 * SSE request
 
Previous behavior was, when there was a lot of websocket/upgrade/sse request this take a permit from the pool (for http1.1) which will block if there is too many connection.

I think those connections should be out of the pool since they will never be shared. Maybe we can introduce some limits at some points to avoid too many connections but i think this is out of scope for this PR. 